### PR TITLE
Generate contrasting second sentences

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -3,6 +3,7 @@ import logging
 import os
 import hashlib
 import asyncio
+import random
 from typing import Dict, List, Tuple
 from collections import Counter
 
@@ -203,10 +204,24 @@ class ProEngine:
             if first and first[0].isalpha():
                 first = first[0].upper() + first[1:]
             words[0] = first
-            sentence = " ".join(filter(None, words[:5])) + "."
-            if pro_memory.is_unique(sentence):
-                pro_memory.store_response(sentence)
-                return sentence
+            first_words = list(filter(None, words[:5]))
+            sentence = " ".join(first_words) + "."
+            second_len = random.choice([5, 6])
+            second_words = pro_predict.dissimilar(
+                [w.lower() for w in first_words], second_len
+            )
+            if second_words:
+                second_first = second_words[0]
+                if second_first and second_first[0].isalpha():
+                    second_first = second_first[0].upper() + second_first[1:]
+                second_words[0] = second_first
+                second_sentence = " ".join(second_words) + "."
+                response = sentence + " " + second_sentence
+            else:
+                response = sentence
+            if pro_memory.is_unique(response):
+                pro_memory.store_response(response)
+                return response
             if extra_idx < len(dataset_words):
                 attempt_seeds = list(seeds) + [dataset_words[extra_idx]]
             else:

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,8 +1,10 @@
 import asyncio
 import sqlite3
+import random
 
 import pro_engine
 import pro_memory
+import pro_predict
 
 
 def test_response_uses_trigram_prediction():
@@ -14,7 +16,8 @@ def test_response_uses_trigram_prediction():
     }
     engine.state["word_counts"] = {"foo": 2, "bar": 3, "baz": 4}
     sentence = engine.respond(["hello", "WORLD"])
-    assert sentence == "Hello WORLD foo bar baz."
+    first_sentence = sentence.split(".")[0] + "."
+    assert first_sentence == "Hello WORLD foo bar baz."
 
 
 def test_predict_next_word_fallback_to_bigram():
@@ -37,7 +40,8 @@ def test_preserves_first_word_capitalization():
         "today": 1,
     }
     sentence = engine.respond(["NASA", "launch"])
-    assert sentence == "NASA launch window opens today."
+    first_sentence = sentence.split(".")[0] + "."
+    assert first_sentence == "NASA launch window opens today."
 
 
 def test_duplicate_responses_suppressed(tmp_path, monkeypatch):
@@ -66,3 +70,47 @@ def test_duplicate_responses_suppressed(tmp_path, monkeypatch):
     count = cur.fetchone()[0]
     conn.close()
     assert count == 2
+
+
+def _stub_dissimilar(words, count):
+    return [f"w{i}" for i in range(count)]
+
+
+def test_second_sentence_length(monkeypatch):
+    engine = pro_engine.ProEngine()
+    engine.state["trigram_counts"] = {
+        ("a", "b"): {"c": 1},
+        ("b", "c"): {"d": 1},
+        ("c", "d"): {"e": 1},
+    }
+    engine.state["word_counts"] = {"c": 1, "d": 1, "e": 1}
+    monkeypatch.setattr(pro_memory, "is_unique", lambda x: True)
+    monkeypatch.setattr(pro_memory, "store_response", lambda x: None)
+    monkeypatch.setattr(pro_predict, "dissimilar", _stub_dissimilar)
+    monkeypatch.setattr(random, "choice", lambda seq: 5)
+    resp = engine.respond(["a", "b"])
+    second_words = resp.split(".")[1].strip().split()
+    assert len(second_words) == 5
+    monkeypatch.setattr(random, "choice", lambda seq: 6)
+    resp = engine.respond(["a", "b"])
+    second_words = resp.split(".")[1].strip().split()
+    assert len(second_words) == 6
+
+
+def test_no_shared_words_between_sentences(monkeypatch):
+    engine = pro_engine.ProEngine()
+    engine.state["trigram_counts"] = {
+        ("hello", "world"): {"foo": 1},
+        ("world", "foo"): {"bar": 1},
+        ("foo", "bar"): {"baz": 1},
+    }
+    engine.state["word_counts"] = {"foo": 1, "bar": 1, "baz": 1}
+    monkeypatch.setattr(pro_memory, "is_unique", lambda x: True)
+    monkeypatch.setattr(pro_memory, "store_response", lambda x: None)
+    monkeypatch.setattr(pro_predict, "dissimilar", _stub_dissimilar)
+    monkeypatch.setattr(random, "choice", lambda seq: 5)
+    resp = engine.respond(["hello", "world"])
+    parts = resp.split(".")
+    first_words = set(parts[0].lower().split())
+    second_words = set(parts[1].strip().lower().split())
+    assert first_words.isdisjoint(second_words)


### PR DESCRIPTION
## Summary
- Extend engine responses with a randomly sized (5-6 words) second sentence using low-similarity vocabulary.
- Add `dissimilar` helper to select minimally related words and avoid overlap with the first sentence.
- Test second-sentence length variability and ensure sentences do not share words.

## Testing
- `flake8 pro_engine.py pro_predict.py tests/test_response.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b21a4806b483298291df7be646b0c5