### PR TITLE
Expand memory fetch and vocabulary

### DIFF
--- a/pro_rag.py
+++ b/pro_rag.py
@@ -5,7 +5,7 @@ import pro_memory
 
 async def retrieve(query_words: List[str], limit: int = 5) -> List[str]:
     """Retrieve relevant messages from memory based on word overlap."""
-    messages = await pro_memory.fetch_recent(50)
+    messages, _ = await pro_memory.fetch_recent(50)
     qset = set(lowercase(query_words))
     scored = []
     for msg in messages:

--- a/tests/test_memory_rag_integration.py
+++ b/tests/test_memory_rag_integration.py
@@ -70,5 +70,5 @@ def test_sqlite_connection_open_close(engine, monkeypatch):
     monkeypatch.setattr(sqlite3, "connect", tracking_connect)
 
     asyncio.run(engine.process_message("another message"))
-    assert counts["connect"] == 5
-    assert counts["close"] == 5
+    assert counts["connect"] == 6
+    assert counts["close"] == 6

--- a/tests/test_predict_update.py
+++ b/tests/test_predict_update.py
@@ -12,7 +12,11 @@ def test_predict_learns_new_words(tmp_path, monkeypatch):
 
     engine = pro_engine.ProEngine()
 
-    monkeypatch.setattr(pro_engine.ProEngine, "respond", lambda self, seeds: "music")
+    monkeypatch.setattr(
+        pro_engine.ProEngine,
+        "respond",
+        lambda self, seeds, vocab=None: "music",
+    )
 
     async def dummy_retrieve(words, limit=5):
         return []

--- a/tests/test_transformer_integration.py
+++ b/tests/test_transformer_integration.py
@@ -32,7 +32,7 @@ def test_process_message_blends_transformer(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_respond(seed_words):
+    def fake_respond(seed_words, vocab=None):
         captured["seed_words"] = list(seed_words)
         return "ok"
 


### PR DESCRIPTION
## Summary
- have `fetch_recent` return both messages and responses
- build weighted vocabulary from memory and datasets before generating replies
- boost overlapping words in `respond` while tracking uniqueness

## Testing
- `python -m pyflakes pro_engine.py pro_memory.py pro_rag.py tests/test_memory_rag_integration.py tests/test_predict_update.py tests/test_transformer_integration.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b22a15ffd88329a8853102b5d3f2d5