### PR TITLE
Add chaos-controlled inverse-frequency generator

### DIFF
--- a/pro_sequence.py
+++ b/pro_sequence.py
@@ -7,19 +7,33 @@ def analyze_sequences(state: Dict, words: List[str], char_n: int = 3) -> None:
     bc = state.setdefault('bigram_counts', {})
     tc = state.setdefault('trigram_counts', {})
     cnc = state.setdefault('char_ngram_counts', {}) if char_n else None
+    # Inverse-frequency maps
+    wi = state.setdefault('word_inv', {})
+    bi = state.setdefault('bigram_inv', {})
+    ti = state.setdefault('trigram_inv', {})
+    cni = state.setdefault('char_ngram_inv', {}) if char_n else None
+
     prev2 = '<s>'
     prev1 = '<s>'
     wc[prev1] = wc.get(prev1, 0) + 1
+    wi[prev1] = 1.0 / wc[prev1]
     wc[prev2] = wc.get(prev2, 0) + 1
+    wi[prev2] = 1.0 / wc[prev2]
     for word in words:
         wc[word] = wc.get(word, 0) + 1
+        wi[word] = 1.0 / wc[word]
         bc.setdefault(prev1, {})
         bc[prev1][word] = bc[prev1].get(word, 0) + 1
+        bi.setdefault(prev1, {})
+        bi[prev1][word] = 1.0 / bc[prev1][word]
         key: Tuple[str, str] = (prev2, prev1)
         tc.setdefault(key, {})
         tc[key][word] = tc[key].get(word, 0) + 1
+        ti.setdefault(key, {})
+        ti[key][word] = 1.0 / tc[key][word]
         if cnc is not None:
             for i in range(len(word) - char_n + 1):
                 ngram = word[i : i + char_n]
                 cnc[ngram] = cnc.get(ngram, 0) + 1
+                cni[ngram] = 1.0 / cnc[ngram]
         prev2, prev1 = prev1, word

--- a/pro_tune.py
+++ b/pro_tune.py
@@ -27,6 +27,8 @@ def train(state: Dict, dataset_path: str) -> Dict:
 
 def _serialize_state(state: Dict) -> Dict:
     data = dict(state)
+    for k in ['word_inv', 'bigram_inv', 'trigram_inv', 'char_ngram_inv']:
+        data.pop(k, None)
     tc = {
         f"{k[0]}{_SEP}{k[1]}": v
         for k, v in state.get('trigram_counts', {}).items()

--- a/tests/test_chaos_factor.py
+++ b/tests/test_chaos_factor.py
@@ -1,0 +1,33 @@
+import random
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pro_engine
+import pro_sequence
+
+
+def test_inverse_frequency_and_chaos_unique():
+    state = {
+        'word_counts': {},
+        'bigram_counts': {},
+        'trigram_counts': {},
+        'char_ngram_counts': {},
+    }
+    pro_sequence.analyze_sequences(state, ["foo", "bar", "foo"])
+    assert state['word_inv']["foo"] == pytest.approx(0.5)
+    assert state['word_inv']["bar"] == pytest.approx(1.0)
+
+    engine = pro_engine.ProEngine()
+    engine.state = state
+
+    random.seed(0)
+    seq0 = engine.plan_sentence([], 2, chaos_factor=0.0)
+    assert seq0[0] == "foo"
+
+    random.seed(0)
+    seq1 = engine.plan_sentence([], 2, chaos_factor=1000.0)
+    assert seq1[0] == "bar"
+    assert len({w.lower() for w in seq1}) == len(seq1)


### PR DESCRIPTION
## Summary
- compute inverse-frequency scores for all n-grams
- add chaos_factor to randomly boost rare n-grams during generation
- ensure state serialization ignores inverse maps and add regression tests

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b22b6e87808329882b849ef098a4e3