### PR TITLE
Add pronoun swapping and test

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -19,6 +19,7 @@ import pro_sequence
 import pro_memory
 import pro_rag
 import pro_predict
+from pro_identity import swap_pronouns
 
 STATE_PATH = 'pro_state.json'
 HASH_PATH = 'dataset_sha.json'
@@ -418,6 +419,7 @@ class ProEngine:
     async def process_message(self, message: str) -> Tuple[str, Dict]:
         original_words = tokenize(message)
         words = lowercase(original_words)
+        words = swap_pronouns(words)
         unknown: List[str] = [
             w for w in words if w not in self.state['word_counts']
         ]

--- a/pro_identity.py
+++ b/pro_identity.py
@@ -1,0 +1,14 @@
+from typing import List
+
+PRONOUN_MAP = {
+    "you": "I",
+    "your": "my",
+    "yours": "mine",
+    "yourself": "myself",
+    "yourselves": "ourselves",
+}
+
+
+def swap_pronouns(tokens: List[str]) -> List[str]:
+    """Swap first and second person pronouns using PRONOUN_MAP."""
+    return [PRONOUN_MAP.get(tok, tok) for tok in tokens]

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,5 @@
+from pro_identity import swap_pronouns
+
+
+def test_swap_pronouns_basic():
+    assert swap_pronouns(["you", "see", "me"]) == ["I", "see", "me"]


### PR DESCRIPTION
## Summary
- Add `swap_pronouns` helper to convert second-person to first-person tokens
- Use pronoun swapping in `ProEngine.process_message`
- Test `swap_pronouns` for basic behavior

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b236f1222883298d26ba948a90b77f