### PR TITLE
Replace user tokens with suggested analogs

### DIFF
--- a/tests/test_forbidden_synonyms.py
+++ b/tests/test_forbidden_synonyms.py
@@ -1,0 +1,38 @@
+import asyncio
+import pro_engine
+import pro_memory
+import pro_predict
+
+
+def test_forbidden_words_replaced(tmp_path, monkeypatch):
+    db_path = tmp_path / "mem.db"
+    monkeypatch.setattr(pro_memory, "DB_PATH", str(db_path))
+    asyncio.run(pro_memory.init_db())
+    engine = pro_engine.ProEngine()
+    engine.state["trigram_counts"] = {
+        ("hi", "earth"): {"foo": 2},
+        ("earth", "foo"): {"bar": 3},
+        ("foo", "bar"): {"baz": 4},
+    }
+    engine.state["word_counts"] = {
+        "hi": 2,
+        "earth": 2,
+        "foo": 3,
+        "bar": 4,
+        "baz": 5,
+    }
+    monkeypatch.setattr(pro_predict, "suggest", lambda w, topn=3: {"hello": ["hi"], "world": ["earth"]}.get(w, []))
+    monkeypatch.setattr(pro_predict, "lookup_analogs", lambda w: None)
+    monkeypatch.setattr(pro_predict, "_VECTORS", {
+        "hi": {"a": 1.0},
+        "earth": {"a": 0.9},
+        "foo": {"a": 0.8},
+        "bar": {"a": 0.7},
+        "baz": {"a": 0.6},
+        "qux": {"b": 1.0},
+    })
+    sentence = engine.respond(["hello", "world"], forbidden={"hello", "world"})
+    assert "hello" not in sentence.lower()
+    assert "world" not in sentence.lower()
+    assert "hi" in sentence.lower()
+    assert "earth" in sentence.lower()

--- a/tests/test_predict_update.py
+++ b/tests/test_predict_update.py
@@ -15,7 +15,7 @@ def test_predict_learns_new_words(tmp_path, monkeypatch):
     monkeypatch.setattr(
         pro_engine.ProEngine,
         "respond",
-        lambda self, seeds, vocab=None: "music",
+        lambda self, seeds, vocab=None, **kwargs: "music",
     )
 
     async def dummy_retrieve(words, limit=5):

--- a/tests/test_transformer_integration.py
+++ b/tests/test_transformer_integration.py
@@ -32,7 +32,7 @@ def test_process_message_blends_transformer(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_respond(seed_words, vocab=None):
+    def fake_respond(seed_words, vocab=None, **kwargs):
         captured["seed_words"] = list(seed_words)
         return "ok"
 


### PR DESCRIPTION
## Summary
- Mark user message tokens as forbidden and suggest analog replacements
- Swap forbidden tokens for predicted synonyms before finalizing responses
- Add tests covering synonym replacement and updated capitalization behaviour

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b245613a1c8329a9d6fac6030db76f