### PR TITLE
Persist and incrementally update prediction vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ pro_state.json
 dataset_sha.json
 pro.log
 pro_memory.db
+pro_predict.pkl

--- a/pro_engine.py
+++ b/pro_engine.py
@@ -46,6 +46,7 @@ class ProEngine:
     async def setup(self) -> None:
         pro_predict._GRAPH = {}
         pro_predict._VECTORS = {}
+        pro_predict.load_vectors()
         if os.path.exists(STATE_PATH):
             self.state = pro_tune.load_state(STATE_PATH)
         for key in [


### PR DESCRIPTION
## Summary
- Persist co-occurrence graph and embedding vectors to `pro_predict.pkl` with load/save helpers
- Recompute embeddings only for words touched by `update` instead of rebuilding entire matrix
- Load stored prediction vectors during `ProEngine.setup`

## Testing
- `flake8 pro_predict.py pro_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b248696b1c832993d4f8faaf6a48b7