### PR TITLE
Add aiosqlite dependency and adjust memory test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-asyncio
 numpy
+aiosqlite

--- a/tests/test_memory_rag_integration.py
+++ b/tests/test_memory_rag_integration.py
@@ -70,5 +70,7 @@ def test_sqlite_connection_open_close(engine, monkeypatch):
     monkeypatch.setattr(sqlite3, "connect", tracking_connect)
 
     asyncio.run(engine.process_message("another message"))
-    assert counts["connect"] == 6
-    assert counts["close"] == 6
+    # With a persistent aiosqlite connection, only one additional synchronous
+    # sqlite3 connection should be opened for the uniqueness check.
+    assert counts["connect"] == 1
+    assert counts["close"] == 1


### PR DESCRIPTION
## Summary
- include `aiosqlite` so memory module works in production
- update memory integration test to match persistent SQLite connection usage

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: tests/test_predict_update.py::test_predict_learns_new_words)*

------
https://chatgpt.com/codex/tasks/task_e_68b254990ba0832985f72ed5ced3a639