### PR TITLE
chore: reorder imports for telegram bot

### DIFF
--- a/pro_tg.py
+++ b/pro_tg.py
@@ -1,9 +1,9 @@
 """Simple asynchronous Telegram bot using urllib for HTTP requests."""
 
+import os
 import asyncio
 import json
-import os
-from urllib import parse, request
+from urllib import request, parse
 
 from pro_engine import ProEngine
 
@@ -39,7 +39,8 @@ async def get_updates(offset: int | None = None) -> list[dict]:
 async def send_message(chat_id: int, text: str) -> None:
     url = f"{API_URL}/sendMessage"
     payload = json.dumps({"chat_id": chat_id, "text": text}).encode()
-    req = request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+    headers = {"Content-Type": "application/json"}
+    req = request.Request(url, data=payload, headers=headers)
     await _request(req)
 
 


### PR DESCRIPTION
## Summary
- reorder imports and adjust urllib import order in `pro_tg.py`
- break long request header line for readability

## Testing
- `flake8 pro_tg.py`
- `pytest`
- `TELEGRAM_TOKEN=dummy timeout 15 python pro_tg.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2541d5eb083298eb9f499d888383f