### PR TITLE
Avoid trailing conjunctions in generated sentences

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -467,9 +467,13 @@ class ProEngine:
             words2[0] = first2
             sentence2 = " ".join(filter(None, words2[:target_length2])) + "."
             last1 = sentence1.rstrip(".").split()[-1].lower()
-            if last1 in {"the", "a"}:
+            if last1 in {"the", "a", "and", "or"}:
                 replacement = next(
-                    (w for w in ordered if w.lower() not in {"the", "a"}),
+                    (
+                        w
+                        for w in ordered
+                        if w.lower() not in {"the", "a", "and", "or"}
+                    ),
                     last1,
                 )
                 parts = sentence1.rstrip(".").split()
@@ -477,9 +481,13 @@ class ProEngine:
                 sentence1 = " ".join(parts) + "."
 
             last2 = sentence2.rstrip(".").split()[-1].lower()
-            if last2 in {"the", "a"}:
+            if last2 in {"the", "a", "and", "or"}:
                 replacement2 = next(
-                    (w for w in ordered2 if w.lower() not in {"the", "a"}),
+                    (
+                        w
+                        for w in ordered2
+                        if w.lower() not in {"the", "a", "and", "or"}
+                    ),
                     last2,
                 )
                 parts2 = sentence2.rstrip(".").split()

--- a/tests/test_forbidden_synonyms.py
+++ b/tests/test_forbidden_synonyms.py
@@ -31,7 +31,9 @@ def test_forbidden_words_replaced(tmp_path, monkeypatch):
         "baz": {"a": 0.6},
         "qux": {"b": 1.0},
     })
-    sentence = engine.respond(["hello", "world"], forbidden={"hello", "world"})
+    sentence = asyncio.run(
+        engine.respond(["hello", "world"], forbidden={"hello", "world"})
+    )
     assert "hello" not in sentence.lower()
     assert "world" not in sentence.lower()
     assert "hi" in sentence.lower()

--- a/tests/test_predict_update.py
+++ b/tests/test_predict_update.py
@@ -12,11 +12,10 @@ def test_predict_learns_new_words(tmp_path, monkeypatch):
 
     engine = pro_engine.ProEngine()
 
-    monkeypatch.setattr(
-        pro_engine.ProEngine,
-        "respond",
-        lambda self, seeds, vocab=None, **kwargs: "music",
-    )
+    async def fake_respond(self, seeds, vocab=None, **kwargs):
+        return "music"
+
+    monkeypatch.setattr(pro_engine.ProEngine, "respond", fake_respond)
 
     async def dummy_retrieve(words, limit=5):
         return []

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -57,7 +57,7 @@ def test_response_uses_trigram_prediction(tmp_path, monkeypatch):
         "exists",
         lambda p, _real=real_exists: False if p == "datasets" else _real(p),
     )
-    sentence = engine.respond(["hello", "WORLD"])
+    sentence = asyncio.run(engine.respond(["hello", "WORLD"]))
     first_words, second_words = _split_two_sentences(sentence)
     metrics = pro_metrics.compute_metrics(
         ["hello", "world"],
@@ -120,7 +120,7 @@ def test_preserves_first_word_capitalization(tmp_path, monkeypatch):
         "opens": 1,
         "today": 1,
     }
-    sentence = engine.respond(["NASA", "launch"])
+    sentence = asyncio.run(engine.respond(["NASA", "launch"]))
     first_words, second_words = _split_two_sentences(sentence)
     metrics = pro_metrics.compute_metrics(
         ["nasa", "launch"],
@@ -172,8 +172,8 @@ def test_duplicate_responses_suppressed(tmp_path, monkeypatch):
         "bar": 2,
         "baz": 1,
     }
-    first = engine.respond(["hello", "world"])
-    second = engine.respond(["hello", "world"])
+    first = asyncio.run(engine.respond(["hello", "world"]))
+    second = asyncio.run(engine.respond(["hello", "world"]))
     f1_first, f1_second = _split_two_sentences(first)
     f2_first, f2_second = _split_two_sentences(second)
     metrics = pro_metrics.compute_metrics(
@@ -250,8 +250,8 @@ def test_response_variable_length_output(tmp_path, monkeypatch):
     monkeypatch.setattr(pro_memory, "DB_PATH", str(db_path))
     asyncio.run(pro_memory.init_db())
     engine = pro_engine.ProEngine()
-    sentence1 = engine.respond(["a", "b"])
-    sentence2 = engine.respond(["a", "b", "c", "d"])
+    sentence1 = asyncio.run(engine.respond(["a", "b"]))
+    sentence2 = asyncio.run(engine.respond(["a", "b", "c", "d"]))
     f1_first, f1_second = _split_two_sentences(sentence1)
     f2_first, f2_second = _split_two_sentences(sentence2)
     metrics1 = pro_metrics.compute_metrics(

--- a/tests/test_transformer_integration.py
+++ b/tests/test_transformer_integration.py
@@ -20,7 +20,10 @@ def test_process_message_blends_transformer(tmp_path, monkeypatch):
     engine.state["word_counts"] = {"hello": 1, "world": 1, "foo": 1, "baz": 1}
     engine.state["bigram_counts"] = {"world": {"foo": 1}}
     engine.state["trigram_counts"] = {("hello", "world"): {"foo": 1}}
-    monkeypatch.setattr(pro_rag, "retrieve", lambda words: [])
+    async def fake_retrieve(words):
+        return []
+
+    monkeypatch.setattr(pro_rag, "retrieve", fake_retrieve)
 
     called = {}
 
@@ -32,7 +35,7 @@ def test_process_message_blends_transformer(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_respond(seed_words, vocab=None, **kwargs):
+    async def fake_respond(seed_words, vocab=None, **kwargs):
         captured["seed_words"] = list(seed_words)
         return "ok"
 


### PR DESCRIPTION
## Summary
- Prevent first or second sentence from ending with conjunctions `and` or `or`
- Update tests to await `ProEngine.respond` and asynchronous helpers

## Testing
- `ruff check pro_engine.py tests/test_forbidden_synonyms.py tests/test_response.py tests/test_predict_update.py tests/test_transformer_integration.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2576146388329824119c56e0e9634