### PR TITLE
Add embedding-based retrieval to RAG memory

### DIFF
--- a/pro_memory_pool.py
+++ b/pro_memory_pool.py
@@ -22,12 +22,17 @@ async def init_pool(db_path: str, size: int = 1) -> None:
         conn = _POOL[0]
         conn.execute(
             "CREATE TABLE IF NOT EXISTS messages("  # noqa: E501
-            "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)"
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT, embedding BLOB)"
         )
         conn.execute(
             "CREATE TABLE IF NOT EXISTS responses("  # noqa: E501
             "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)"
         )
+        # Ensure embedding column exists for pre-existing databases
+        try:
+            conn.execute("ALTER TABLE messages ADD COLUMN embedding BLOB")
+        except sqlite3.OperationalError:
+            pass
         conn.commit()
 
 

--- a/pro_rag.py
+++ b/pro_rag.py
@@ -1,17 +1,24 @@
 from typing import List
+
+import numpy as np
+
 from pro_metrics import tokenize, lowercase
 import pro_memory
+import pro_rag_embedding
 
 
 async def retrieve(query_words: List[str], limit: int = 5) -> List[str]:
-    """Retrieve relevant messages from memory based on word overlap."""
-    messages, _ = await pro_memory.fetch_recent(50)
+    """Retrieve relevant messages combining word overlap and embedding similarity."""
+    messages = await pro_memory.fetch_recent_messages(50)
     qset = set(lowercase(query_words))
+    query_emb = await pro_rag_embedding.embed_sentence(' '.join(query_words))
     scored = []
-    for msg in messages:
+    for msg, emb in messages:
         words = lowercase(tokenize(msg))
-        score = len(qset.intersection(words))
-        if score:
+        word_score = len(qset.intersection(words))
+        cos_sim = float(np.dot(query_emb, emb))
+        score = word_score + cos_sim
+        if score > 0:
             scored.append((score, msg))
     scored.sort(reverse=True)
     return [m for _, m in scored[:limit]]

--- a/pro_rag_embedding.py
+++ b/pro_rag_embedding.py
@@ -1,0 +1,27 @@
+import numpy as np
+import asyncio
+
+# Simple deterministic "mini-SIAMESE" style embedding generator.
+# This is intentionally lightweight so tests do not require heavy models.
+_DIM = 32
+_W = np.random.default_rng(0).normal(size=(256, _DIM)).astype(np.float32)
+_LOCK = asyncio.Lock()
+
+
+def _char_vector(text: str) -> np.ndarray:
+    vec = np.zeros(256, dtype=np.float32)
+    for ch in text.lower():
+        vec[ord(ch) % 256] += 1.0
+    return vec
+
+
+async def embed_sentence(text: str) -> np.ndarray:
+    """Return a normalized embedding for given text."""
+    async with _LOCK:
+        # embedding = char histogram projected via fixed random matrix
+        vec = _char_vector(text)
+        emb = vec @ _W
+        norm = np.linalg.norm(emb)
+        if norm:
+            emb = emb / norm
+        return emb.astype(np.float32)


### PR DESCRIPTION
## Summary
- add a lightweight mini-SIAMESE embedding generator
- persist message embeddings in SQLite and expose retrieval helper
- combine word overlap with cosine embedding similarity for context lookup

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b25cccb60883299d08cd7aee43252f