### PR TITLE
Avoid article 'a' next to pronouns

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -250,6 +250,13 @@ class ProEngine:
                     ]
                 for cand in ordered[: beam_width * 2]:
                     lw = cand.lower()
+                    if seq:
+                        prev_lw = seq[-1].lower()
+                        if (
+                            (prev_lw == "a" and lw in {"you", "i"})
+                            or (lw == "a" and prev_lw in {"you", "i"})
+                        ):
+                            continue
                     if lw in used:
                         continue
                     new_seq = seq + [cand]

--- a/pro_predict.py
+++ b/pro_predict.py
@@ -92,6 +92,9 @@ def suggest(word: str, topn: int = 3) -> List[str]:
     fuzzy string match against the vocabulary is performed.
     """
     _ensure_vectors()
+    neighbours = _GRAPH.get(word)
+    if neighbours:
+        return [w for w, _ in neighbours.most_common(topn)]
     if word in _VECTORS:
         vec = _VECTORS[word]
         scores: Dict[str, float] = {}
@@ -107,8 +110,7 @@ def suggest(word: str, topn: int = 3) -> List[str]:
             scores[other] = dot / (norm_a * norm_b)
         ordered = sorted(scores.items(), key=lambda x: x[1], reverse=True)
         return [w for w, _ in ordered[:topn]]
-    vocab = list(_VECTORS.keys())
-    return difflib.get_close_matches(word, vocab, n=topn)
+    return []
 
 
 def lookup_analogs(word: str) -> Optional[str]:


### PR DESCRIPTION
## Summary
- prevent beam search from placing the article 'a' adjacent to pronouns "you" or "I"
- prioritize direct co-occurrence neighbours and drop fuzzy fallback when suggesting related words

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b25ba15ea48329a9cdc7632813bc66