### PR TITLE
Queue-based background update for predictions

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -701,7 +701,9 @@ class ProEngine:
             self.state,
             lowercase(tokenize(response)),
         )
-        await pro_predict.update(words + lowercase(tokenize(response)))
+        await pro_predict.enqueue_tokens(
+            words + lowercase(tokenize(response))
+        )
         try:
             await self.save_state()
         except Exception as exc:  # pragma: no cover - logging side effect


### PR DESCRIPTION
## Summary
- add async token queue and background updater for prediction embeddings
- route message token updates through queue rather than direct update
- restrict suggestions to known vocabulary only

## Testing
- `flake8` *(fails: line too long and other style issues)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2601fff608329970b245348980273