### PR TITLE
Enforce single-letter punctuation rule

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -269,6 +269,8 @@ class ProEngine:
 
         Candidates are scored by combining entropy and trigram perplexity.
         Paths that would repeat words (case-insensitive) are discarded.
+        Additionally, no more than two single-letter words may appear
+        consecutively and a sentence cannot end with two single letters.
         """
         trigram_counts = self.state.get("trigram_counts", {})
         bigram_counts = self.state.get("bigram_counts", {})
@@ -319,6 +321,11 @@ class ProEngine:
                             or (lw == "a" and prev_lw in {"you", "i"})
                         ):
                             continue
+                        if len(cand) == 1 and len(seq[-1]) == 1:
+                            if len(seq) >= 2 and len(seq[-2]) == 1:
+                                continue
+                            if len(seq) + 1 == target_length:
+                                continue
                     if lw in used:
                         continue
                     new_seq = seq + [cand]

--- a/tests/test_single_letter_rule.py
+++ b/tests/test_single_letter_rule.py
@@ -1,0 +1,40 @@
+import pro_engine
+
+
+def test_no_three_single_letters_in_a_row():
+    engine = pro_engine.ProEngine()
+    engine.state["trigram_counts"] = {("a", "b"): {"c": 5, "word": 4}}
+    engine.state["word_counts"] = {"a": 5, "b": 5, "c": 5, "word": 1}
+    engine.state["bigram_counts"] = {}
+    engine.state["char_ngram_counts"] = {}
+    engine.state["trigram_inv"] = {}
+    engine.state["bigram_inv"] = {}
+    engine.state["word_inv"] = {}
+    result = engine.plan_sentence(["a", "b"], 3)
+    assert result == ["a", "b", "word"]
+
+
+def test_sentence_does_not_end_with_two_single_letters():
+    engine = pro_engine.ProEngine()
+    engine.state["trigram_counts"] = {("<s>", "a"): {"b": 5, "word": 4}}
+    engine.state["word_counts"] = {"a": 5, "b": 5, "word": 1}
+    engine.state["bigram_counts"] = {}
+    engine.state["char_ngram_counts"] = {}
+    engine.state["trigram_inv"] = {}
+    engine.state["bigram_inv"] = {}
+    engine.state["word_inv"] = {}
+    result = engine.plan_sentence(["a"], 2)
+    assert result == ["a", "word"]
+
+
+def test_sentence_can_end_with_single_letter_after_longer_word():
+    engine = pro_engine.ProEngine()
+    engine.state["trigram_counts"] = {("<s>", "word"): {"a": 5}}
+    engine.state["word_counts"] = {"word": 5, "a": 5}
+    engine.state["bigram_counts"] = {}
+    engine.state["char_ngram_counts"] = {}
+    engine.state["trigram_inv"] = {}
+    engine.state["bigram_inv"] = {}
+    engine.state["word_inv"] = {}
+    result = engine.plan_sentence(["word"], 2)
+    assert result == ["word", "a"]


### PR DESCRIPTION
## Summary
- Prevent more than two single-letter words in a row and disallow double single-letter endings
- Test planner behavior for single-letter sequences and valid endings

## Testing
- `python -m py_compile pro_engine.py tests/test_single_letter_rule.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b269b18f248329afa069d00c4e8951