### PR TITLE
Guard prediction vectors with shared asyncio lock

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -494,7 +494,7 @@ class ProEngine:
             tracker = set(first_words)
 
             # ----- Second sentence: choose semantically distant seeds -----
-            pro_predict._ensure_vectors()
+            await asyncio.to_thread(pro_predict._ensure_vectors)
             vectors = pro_predict._VECTORS
 
             def _cos(a: Dict[str, float], b: Dict[str, float]) -> float:


### PR DESCRIPTION
## Summary
- Add a global `asyncio.Lock` and context manager to protect shared embedding data
- Wrap `update` and `suggest` operations with the shared lock to avoid races
- Ensure async callers use `to_thread` when ensuring vectors

## Testing
- `python -m flake8 pro_engine.py`
- `python -m flake8 pro_predict.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b269d8fe348329bac86c9de7e9702d