### PR TITLE
feat: add transformer training and persistence

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -818,6 +818,13 @@ class ProEngine:
         await pro_predict.enqueue_tokens(
             words + lowercase(tokenize(response))
         )
+        vocab_list = list(self.state.get("word_counts", {}).keys())
+        if vocab_list:
+            asyncio.create_task(
+                pro_predict.update_transformer(
+                    vocab_list, recent_msgs, recent_resps
+                )
+            )
         try:
             await self.save_state()
         except Exception as exc:  # pragma: no cover - logging side effect


### PR DESCRIPTION
## Summary
- persist tiny transformer weights to `pro_transformer.npz`
- train transformer with cross-entropy on recent conversations
- schedule async transformer updates during message processing
- test that logits shift after training

## Testing
- `ruff check pro_predict.py pro_engine.py tests/test_transformer_integration.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b271a2344083299346675f3d3a8e44