### PR TITLE
Use predictive vectors for memory retrieval

### DIFF
--- a/pro_rag.py
+++ b/pro_rag.py
@@ -1,23 +1,50 @@
-from typing import List
+from typing import Dict, List
 
-import numpy as np
+import asyncio
+import math
 
 from pro_metrics import tokenize, lowercase
 import pro_memory
-import pro_rag_embedding
+import pro_predict
+
+
+def _sentence_vector(words: List[str]) -> Dict[str, float]:
+    vec: Dict[str, float] = {}
+    for w in words:
+        wvec = pro_predict._VECTORS.get(w)
+        if not wvec:
+            continue
+        for k, v in wvec.items():
+            vec[k] = vec.get(k, 0.0) + v
+    return vec
+
+
+def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
+    keys = set(a) | set(b)
+    dot = sum(a.get(k, 0.0) * b.get(k, 0.0) for k in keys)
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
 
 
 async def retrieve(query_words: List[str], limit: int = 5) -> List[str]:
     """Retrieve relevant messages combining word overlap and embedding similarity."""
+    await asyncio.to_thread(pro_predict._ensure_vectors)
     messages = await pro_memory.fetch_recent_messages(50)
-    qset = set(lowercase(query_words))
-    query_emb = await pro_rag_embedding.embed_sentence(' '.join(query_words))
+    qwords = lowercase(query_words)
+    qset = set(qwords)
+    qvec = _sentence_vector(qwords)
     scored = []
-    for msg, emb in messages:
+    for msg, _ in messages:
         words = lowercase(tokenize(msg))
         word_score = len(qset.intersection(words))
-        cos_sim = float(np.dot(query_emb, emb))
-        score = word_score + cos_sim
+        mvec = _sentence_vector(words)
+        if qvec and mvec:
+            score = word_score + _cosine(qvec, mvec)
+        else:
+            score = word_score
         if score > 0:
             scored.append((score, msg))
     scored.sort(reverse=True)

--- a/tests/test_memory_rag_integration.py
+++ b/tests/test_memory_rag_integration.py
@@ -81,3 +81,14 @@ def test_sqlite_connection_open_close(engine, monkeypatch):
     # With a pooled sqlite connection, no new connections should be opened.
     assert counts["connect"] == 0
     assert counts["close"] == 0
+
+@pytest.mark.asyncio
+async def test_retrieve_vectors_and_word_overlap(engine):
+    await pro_memory.add_message("measurement")
+    await pro_memory.add_message("zzyzx")
+
+    result = await pro_rag.retrieve(["science"])
+    assert result == ["measurement"]
+
+    result = await pro_rag.retrieve(["zzyzx"])
+    assert result == ["zzyzx"]


### PR DESCRIPTION
## Summary
- compute sentence vectors from predictive embeddings and use cosine similarity to rank stored messages, falling back to word overlap when vectors are missing
- cover vector similarity and word-overlap fallback in memory retrieval tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b271fb478083298a1555766a0660ec