### PR TITLE
Fix second-sentence single-letter endings

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -568,7 +568,7 @@ class ProEngine:
             )
             words2 = await asyncio.to_thread(
                 self.plan_sentence,
-                second_seeds + ordered,
+                second_seeds,
                 target_length2,
                 forbidden=set(first_words) | forbidden,
                 chaos_factor=cf,

--- a/tests/test_single_letter_rule.py
+++ b/tests/test_single_letter_rule.py
@@ -1,4 +1,7 @@
+import asyncio
+
 import pro_engine
+import pro_predict
 
 
 def test_no_three_single_letters_in_a_row():
@@ -38,3 +41,30 @@ def test_sentence_can_end_with_single_letter_after_longer_word():
     engine.state["word_inv"] = {}
     result = engine.plan_sentence(["word"], 2)
     assert result == ["word", "a"]
+
+
+def test_second_sentence_respects_single_letter_rule(monkeypatch):
+    engine = pro_engine.ProEngine()
+    engine.state["word_counts"] = {"x": 5, "a": 4, "b": 3, "c": 2, "d": 1}
+    engine.state["bigram_counts"] = {}
+    engine.state["trigram_counts"] = {}
+    engine.state["char_ngram_counts"] = {}
+    engine.state["trigram_inv"] = {}
+    engine.state["bigram_inv"] = {}
+    engine.state["word_inv"] = {}
+
+    monkeypatch.setattr(pro_predict, "lookup_analogs", lambda w: w)
+    monkeypatch.setattr(pro_predict, "_ensure_vectors", lambda: None)
+    pro_predict._VECTORS = {w: {w: 1.0} for w in engine.state["word_counts"]}
+
+    def fake_plan_sentence(self, initial, target_length, **kwargs):
+        if len(initial) > 2:
+            return initial[:target_length]
+        return ["word"] * (target_length - 1) + ["a"]
+
+    monkeypatch.setattr(pro_engine.ProEngine, "plan_sentence", fake_plan_sentence, raising=False)
+
+    sentence = asyncio.run(engine.respond(["x"]))
+    _, second = sentence.split(". ")
+    last_words = second.rstrip(".").split()
+    assert not (len(last_words[-1]) == len(last_words[-2]) == 1)


### PR DESCRIPTION
## Summary
- Prevent `respond` from feeding a large vocabulary list into `plan_sentence`
- Add regression test ensuring second sentence never ends with multiple single-letter words

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b275b908c08329bd809077d4ee9faf