### PR TITLE
Add dynamic context gate to attention

### DIFF
--- a/tests/attention/test_dynamic_context_gate.py
+++ b/tests/attention/test_dynamic_context_gate.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from pro_predict import MiniSelfAttention
+
+
+def test_gate_can_zero_context():
+    vocab = ["a", "b"]
+    model = MiniSelfAttention(vocab, dim=4, use_gate=True)
+    tokens = ["a"]
+    baseline = model.logits(tokens)
+    # Force gate to suppress context completely
+    model.gate.bias = np.full(model.dim, -100.0)
+    gated = model.logits(tokens)
+    assert all(abs(v) < 1e-6 for v in gated.values())
+    # With strong positive bias the logits should differ
+    model.gate.bias = np.full(model.dim, 100.0)
+    boosted = model.logits(tokens)
+    assert any(abs(boosted[w]) > abs(baseline[w]) for w in vocab)

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -1,0 +1,3 @@
+from .blocks import DynamicContextGate
+
+__all__ = ["DynamicContextGate"]

--- a/transformers/blocks/__init__.py
+++ b/transformers/blocks/__init__.py
@@ -1,0 +1,3 @@
+from .attention import DynamicContextGate
+
+__all__ = ["DynamicContextGate"]

--- a/transformers/blocks/attention.py
+++ b/transformers/blocks/attention.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+class DynamicContextGate:
+    """Simple dynamic gating for attention contexts.
+
+    The gate computes a sigmoid over the mean context vector plus a learnable
+    bias. The resulting gate scales the context vectors element-wise.
+    """
+
+    def __init__(self, dim: int) -> None:
+        self.bias = np.zeros(dim, dtype=np.float32)
+
+    def __call__(self, context: np.ndarray) -> np.ndarray:
+        """Apply the gating mechanism to *context*.
+
+        Parameters
+        ----------
+        context:
+            Array of shape ``(seq_len, dim)`` representing the attention
+            context vectors.
+        """
+        mean_ctx = context.mean(axis=0)
+        gate = 1.0 / (1.0 + np.exp(-(mean_ctx + self.bias)))
+        return context * gate
+
+    # Saving/loading helpers -------------------------------------------------
+    def state_dict(self) -> dict:
+        return {"bias": self.bias}
+
+    def load_state_dict(self, state: dict) -> None:
+        if "bias" in state:
+            self.bias = state["bias"]


### PR DESCRIPTION
## Summary
- introduce `DynamicContextGate` for modulating attention context
- wire the gate into `MiniSelfAttention` with configurable loading/saving
- add tests for gating behaviour

## Testing
- `python -m py_compile transformers/blocks/attention.py pro_predict.py tests/attention/test_dynamic_context_gate.py`
- `pytest tests/attention/test_dynamic_context_gate.py`


------
https://chatgpt.com/codex/tasks/task_e_68b27617634c8329a536ba26708942e2