### PR TITLE
Add autoadaptive layer monitoring and trainer evaluation

### DIFF
--- a/autoadapt/__init__.py
+++ b/autoadapt/__init__.py
@@ -1,0 +1,38 @@
+import json
+import os
+from typing import Dict, List
+
+
+class LayerMutator:
+    """Track and persist layer modifications."""
+
+    def __init__(self) -> None:
+        self.mutations: Dict[str, float] = {}
+
+    def mutate(self, layer: str, factor: float) -> None:
+        """Apply a simple multiplicative mutation to a layer."""
+        current = self.mutations.get(layer, 1.0)
+        self.mutations[layer] = current * factor
+
+    def save(self, directory: str) -> None:
+        """Persist mutation state to ``directory``."""
+        os.makedirs(directory, exist_ok=True)
+        path = os.path.join(directory, "mutations.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(self.mutations, fh)
+
+
+class MetricMonitor:
+    """Keep a sliding window of metrics and compute averages."""
+
+    def __init__(self, window: int = 10) -> None:
+        self.window = window
+        self.values: List[float] = []
+
+    def record(self, value: float) -> None:
+        self.values.append(value)
+        if len(self.values) > self.window:
+            self.values.pop(0)
+
+    def average(self) -> float:
+        return sum(self.values) / len(self.values) if self.values else 0.0

--- a/trainer.py
+++ b/trainer.py
@@ -1,0 +1,31 @@
+"""Simple training loop with layer evaluation."""
+from autoadapt import LayerMutator, MetricMonitor
+
+
+class Trainer:
+    """Train model and periodically evaluate layer effectiveness."""
+
+    def __init__(
+        self,
+        eval_interval: int = 10,
+        checkpoint_dir: str = "checkpoints/autoadapt",
+    ) -> None:
+        self.eval_interval = eval_interval
+        self.monitor = MetricMonitor()
+        self.mutator = LayerMutator()
+        self.step = 0
+        self.checkpoint_dir = checkpoint_dir
+
+    def train_step(self, layer: str, metric: float) -> None:
+        """Simulate a training step and record metric for ``layer``."""
+        self.monitor.record(metric)
+        self.step += 1
+        if self.step % self.eval_interval == 0:
+            self._evaluate(layer)
+
+    def _evaluate(self, layer: str) -> None:
+        avg = self.monitor.average()
+        if avg < 0.5:
+            # Boost the layer slightly if performance is lacking
+            self.mutator.mutate(layer, 1.1)
+            self.mutator.save(self.checkpoint_dir)


### PR DESCRIPTION
## Summary
- implement `LayerMutator` and `MetricMonitor` classes for tracking layer changes and metrics
- wire up a simple `Trainer` that periodically evaluates layer performance and saves mutation state
- prepare `checkpoints/autoadapt/` directory for persisted mutation data

## Testing
- `flake8 autoadapt trainer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b277409eb88329b7816e2fe5ec217c