### PR TITLE
Support dataset weighting during tuning

### DIFF
--- a/pro_sequence.py
+++ b/pro_sequence.py
@@ -1,7 +1,9 @@
 from typing import Dict, List, Tuple
 
 
-def analyze_sequences(state: Dict, words: List[str], char_n: int = 3) -> None:
+def analyze_sequences(
+    state: Dict, words: List[str], char_n: int = 3, weight: float = 1.0
+) -> None:
     """Update state with word, bigram, trigram and char-level n-gram counts."""
     wc = state.setdefault('word_counts', {})
     bc = state.setdefault('bigram_counts', {})
@@ -15,25 +17,25 @@ def analyze_sequences(state: Dict, words: List[str], char_n: int = 3) -> None:
 
     prev2 = '<s>'
     prev1 = '<s>'
-    wc[prev1] = wc.get(prev1, 0) + 1
+    wc[prev1] = wc.get(prev1, 0) + weight
     wi[prev1] = 1.0 / wc[prev1]
-    wc[prev2] = wc.get(prev2, 0) + 1
+    wc[prev2] = wc.get(prev2, 0) + weight
     wi[prev2] = 1.0 / wc[prev2]
     for word in words:
-        wc[word] = wc.get(word, 0) + 1
+        wc[word] = wc.get(word, 0) + weight
         wi[word] = 1.0 / wc[word]
         bc.setdefault(prev1, {})
-        bc[prev1][word] = bc[prev1].get(word, 0) + 1
+        bc[prev1][word] = bc[prev1].get(word, 0) + weight
         bi.setdefault(prev1, {})
         bi[prev1][word] = 1.0 / bc[prev1][word]
         key: Tuple[str, str] = (prev2, prev1)
         tc.setdefault(key, {})
-        tc[key][word] = tc[key].get(word, 0) + 1
+        tc[key][word] = tc[key].get(word, 0) + weight
         ti.setdefault(key, {})
         ti[key][word] = 1.0 / tc[key][word]
         if cnc is not None:
             for i in range(len(word) - char_n + 1):
                 ngram = word[i:i + char_n]
-                cnc[ngram] = cnc.get(ngram, 0) + 1
+                cnc[ngram] = cnc.get(ngram, 0) + weight
                 cni[ngram] = 1.0 / cnc[ngram]
         prev2, prev1 = prev1, word

--- a/pro_tune.py
+++ b/pro_tune.py
@@ -11,7 +11,12 @@ STATE_PATH = 'pro_state.json'
 _SEP = '\u0001'
 
 
-def train(state: Dict, dataset_path: str) -> Dict:
+def train_weighted(state: Dict, dataset_path: str, weight: float) -> Dict:
+    if weight <= 0:
+        logging.warning(
+            "Non-positive weight %s for %s; skipping", weight, dataset_path
+        )
+        return state
     if not os.path.exists(dataset_path):
         logging.warning(
             "Dataset path %s does not exist; skipping training", dataset_path
@@ -25,8 +30,12 @@ def train(state: Dict, dataset_path: str) -> Dict:
         )
         return state
     words = lowercase(tokenize(text))
-    pro_sequence.analyze_sequences(state, words)
+    pro_sequence.analyze_sequences(state, words, weight=weight)
     return state
+
+
+def train(state: Dict, dataset_path: str) -> Dict:
+    return train_weighted(state, dataset_path, 1.0)
 
 
 def _serialize_state(state: Dict) -> Dict:

--- a/tests/test_engine_resilience.py
+++ b/tests/test_engine_resilience.py
@@ -40,9 +40,9 @@ def test_process_message_resilience(monkeypatch):
 def test_async_tune_resilience(monkeypatch):
     engine = pro_engine.ProEngine()
 
-    def failing_train(state, path):
+    def failing_train(state, path, weight):
         raise RuntimeError("tune fail")
 
-    monkeypatch.setattr(pro_tune, "train", failing_train)
+    monkeypatch.setattr(pro_tune, "train_weighted", failing_train)
 
     asyncio.run(engine._async_tune(["dummy"]))

--- a/tests/test_memory_rag_integration.py
+++ b/tests/test_memory_rag_integration.py
@@ -18,7 +18,7 @@ def engine(monkeypatch):
     for path in [pro_memory.DB_PATH, "pro_state.json", "dataset_sha.json"]:
         if os.path.exists(path):
             os.remove(path)
-    monkeypatch.setattr(pro_tune, "train", lambda *a, **k: None)
+    monkeypatch.setattr(pro_tune, "train_weighted", lambda *a, **k: None)
     eng = ProEngine()
     asyncio.run(eng.setup())
     return eng


### PR DESCRIPTION
## Summary
- add `train_weighted` to tune models with dataset-specific weights
- extend sequence analysis to scale counts by weight
- use `dataset_weights.json` to retrain when weights change and cover with tests

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b27b9793c08329a3b9e3f5c2f5779a