### PR TITLE
Add concept graph storage and retrieval

### DIFF
--- a/pro_memory.py
+++ b/pro_memory.py
@@ -34,6 +34,38 @@ async def add_message(content: str) -> None:
         await asyncio.to_thread(conn.commit)
 
 
+async def add_concept(description: str) -> None:
+    """Extract entities and relations from text and store them."""
+    entities, relations = await pro_rag_embedding.extract_entities_relations(
+        description
+    )
+    if not entities:
+        return
+    async with get_connection() as conn:
+        for ent in entities:
+            await asyncio.to_thread(
+                conn.execute,
+                'INSERT OR IGNORE INTO concepts(name) VALUES (?)',
+                (ent,),
+            )
+        for subj, rel, obj in relations:
+            cur = await asyncio.to_thread(
+                conn.execute, 'SELECT id FROM concepts WHERE name = ?', (subj,)
+            )
+            subj_id = await asyncio.to_thread(cur.fetchone)
+            cur = await asyncio.to_thread(
+                conn.execute, 'SELECT id FROM concepts WHERE name = ?', (obj,)
+            )
+            obj_id = await asyncio.to_thread(cur.fetchone)
+            if subj_id and obj_id:
+                await asyncio.to_thread(
+                    conn.execute,
+                    'INSERT INTO relations(source, target, relation) VALUES (?, ?, ?)',
+                    (subj_id[0], obj_id[0], rel),
+                )
+        await asyncio.to_thread(conn.commit)
+
+
 async def is_unique(sentence: str) -> bool:
     """Return True if sentence not already stored."""
     async with get_connection() as conn:
@@ -88,3 +120,29 @@ async def fetch_recent_messages(limit: int = 50) -> List[Tuple[str, np.ndarray]]
         (r[0], np.frombuffer(r[1], dtype=np.float32)) for r in rows
     ][::-1]
     return messages
+
+
+async def fetch_related_concepts(words: List[str]) -> List[str]:
+    """Return relation sentences touching any of the given words."""
+    results: List[str] = []
+    seen = set()
+    terms = [w.lower() for w in words]
+    async with get_connection() as conn:
+        for term in terms:
+            cur = await asyncio.to_thread(
+                conn.execute,
+                (
+                    "SELECT c1.name, r.relation, c2.name FROM relations r "
+                    "JOIN concepts c1 ON r.source = c1.id "
+                    "JOIN concepts c2 ON r.target = c2.id "
+                    "WHERE LOWER(c1.name) = ? OR LOWER(c2.name) = ?"
+                ),
+                (term, term),
+            )
+            rows = await asyncio.to_thread(cur.fetchall)
+            for s, rel, t in rows:
+                sentence = f"{s} {rel} {t}"
+                if sentence not in seen:
+                    seen.add(sentence)
+                    results.append(sentence)
+    return results

--- a/pro_memory_pool.py
+++ b/pro_memory_pool.py
@@ -28,6 +28,16 @@ async def init_pool(db_path: str, size: int = 1) -> None:
             "CREATE TABLE IF NOT EXISTS responses("  # noqa: E501
             "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)"
         )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS concepts("  # noqa: E501
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE)"
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS relations("  # noqa: E501
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, source INTEGER, target INTEGER, relation TEXT,"
+            "FOREIGN KEY(source) REFERENCES concepts(id),"
+            "FOREIGN KEY(target) REFERENCES concepts(id))"
+        )
         # Ensure embedding column exists for pre-existing databases
         try:
             conn.execute("ALTER TABLE messages ADD COLUMN embedding BLOB")

--- a/pro_rag.py
+++ b/pro_rag.py
@@ -30,7 +30,7 @@ def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
 
 
 async def retrieve(query_words: List[str], limit: int = 5) -> List[str]:
-    """Retrieve relevant messages combining word overlap and embedding similarity."""
+    """Retrieve context combining messages and concept relations."""
     await asyncio.to_thread(pro_predict._ensure_vectors)
     messages = await pro_memory.fetch_recent_messages(50)
     qwords = lowercase(query_words)
@@ -48,4 +48,6 @@ async def retrieve(query_words: List[str], limit: int = 5) -> List[str]:
         if score > 0:
             scored.append((score, msg))
     scored.sort(reverse=True)
-    return [m for _, m in scored[:limit]]
+    graph_context = await pro_memory.fetch_related_concepts(qwords)
+    combined = graph_context + [m for _, m in scored]
+    return combined[:limit]


### PR DESCRIPTION
## Summary
- Persist concepts and relations in new SQLite tables
- Add `add_concept` and concept relation retrieval helpers
- Include concept graph traversal in RAG retrieval

## Testing
- `python -m py_compile pro_memory.py pro_memory_pool.py pro_rag_embedding.py pro_rag.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b27da50b78832998c1b25b363c24a0