### PR TITLE
Add reinforcement-based memory retriever and training demo

### DIFF
--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,0 +1,6 @@
+"""Memory helpers and retrievers."""
+
+from .memory_graph import MemoryGraphStore, GraphRetriever
+from .reinforce_retriever import ReinforceRetriever
+
+__all__ = ["MemoryGraphStore", "GraphRetriever", "ReinforceRetriever"]

--- a/memory/reinforce_retriever.py
+++ b/memory/reinforce_retriever.py
@@ -1,0 +1,81 @@
+"""Policy gradient memory retriever.
+
+This module implements :class:`ReinforceRetriever`, a minimal reinforcement
+learning policy that selects a memory node from ``MemoryGraphStore`` using the
+REINFORCE algorithm.  Memory texts are encoded into fixed-size vectors and a
+softmax over a learnable weight vector produces a probability distribution over
+nodes.  During retrieval the expected memory vector weighted by these
+probabilities is returned which can be fed directly into cross-attention.  The
+:py:meth:`update` method applies an online policy gradient step given a scalar
+reward.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from .memory_graph import MemoryGraphStore
+
+
+class ReinforceRetriever:
+    """Select memory nodes using a lightweight policy gradient."""
+
+    def __init__(self, store: MemoryGraphStore, dim: int = 32, lr: float = 0.1) -> None:
+        self.store = store
+        self.dim = dim
+        self.lr = lr
+        # Parameters for a linear policy mapping encoded messages to logits
+        self.w = np.zeros(dim, dtype=np.float32)
+        # Cached state from the last retrieval for credit assignment
+        self._last: Optional[Tuple[np.ndarray, np.ndarray, int]] = None
+
+    # ------------------------------------------------------------------ utils
+    def _encode(self, text: str) -> np.ndarray:
+        """Encode *text* into a simple numeric vector."""
+        vec = np.zeros(self.dim, dtype=np.float32)
+        if not text:
+            return vec
+        for i, b in enumerate(text.encode("utf-8")):
+            if i >= self.dim:
+                break
+            vec[i] = b / 255.0
+        return vec
+
+    # ---------------------------------------------------------------- retrieval
+    def retrieve(self, dialogue_id: str, speaker: str) -> np.ndarray:
+        """Return a memory vector weighted by retrieval probabilities.
+
+        The method also samples a concrete node whose index is stored so that
+        :py:meth:`update` can assign credit based on an external reward.
+        """
+
+        dialogue = self.store.get_dialogue(dialogue_id)
+        messages = [n.text for n in dialogue if n.speaker == speaker]
+        if not messages:
+            self._last = None
+            return np.zeros(self.dim, dtype=np.float32)
+
+        vecs = np.stack([self._encode(m) for m in messages])  # (n, dim)
+        logits = vecs @ self.w  # (n,)
+        # Numerical stability for softmax
+        exp = np.exp(logits - np.max(logits))
+        probs = exp / exp.sum()
+        idx = int(np.random.choice(len(messages), p=probs))
+        self._last = (vecs, probs, idx)
+        # Expected memory vector used for attention
+        weighted = probs @ vecs
+        return weighted
+
+    # ------------------------------------------------------------------ update
+    def update(self, reward: float) -> None:
+        """Apply an online REINFORCE update with ``reward``."""
+        if self._last is None:
+            return
+        vecs, probs, idx = self._last
+        baseline = probs @ vecs
+        grad = vecs[idx] - baseline
+        self.w += self.lr * reward * grad
+        # Clear state so updates correspond to a single retrieval
+        self._last = None

--- a/transformers/modeling_transformer.py
+++ b/transformers/modeling_transformer.py
@@ -1,25 +1,40 @@
 """Minimal transformer building blocks used in tests and demos.
 
 This file introduces :class:`MemoryAttention`, a simple mechanism that
-injects information retrieved from :class:`~memory.memory_graph.GraphRetriever`
-into a sequence of hidden states.  The goal is not to implement a full
-Transformer model but to provide a lightweight hook where a memory graph
-can influence the computation.
+injects information retrieved from a memory graph into a sequence of hidden
+states.  By default it works with :class:`~memory.memory_graph.GraphRetriever`
+but it can also consume a :class:`~memory.reinforce_retriever.ReinforceRetriever`
+whose probability distribution over nodes defines a soft cross-attention.
+The goal is not to implement a full Transformer model but to provide a
+lightweight hook where a memory graph can influence the computation.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
 from memory.memory_graph import GraphRetriever
+from memory.reinforce_retriever import ReinforceRetriever
 
 
 class MemoryAttention:
-    """Additively combines hidden states with retrieved memory vectors."""
+    """Additively combines hidden states with retrieved memory vectors.
 
-    def __init__(self, retriever: GraphRetriever, dim: int) -> None:
+    If the *retriever* exposes a ``retrieve`` method (as
+    :class:`~memory.reinforce_retriever.ReinforceRetriever` does), the returned
+    vector is assumed to already be weighted by retrieval probabilities which
+    acts as a soft cross-attention over all candidate memories.  Otherwise the
+    most recent message for ``speaker`` is encoded and added to the hidden
+    state.
+    """
+
+    def __init__(
+        self,
+        retriever: Union[GraphRetriever, ReinforceRetriever],
+        dim: int,
+    ) -> None:
         self.retriever = retriever
         self.dim = dim
 
@@ -37,6 +52,12 @@ class MemoryAttention:
         self, hidden_states: np.ndarray, dialogue_id: str, speaker: str
     ) -> np.ndarray:
         """Return ``hidden_states`` enriched with memory from the graph."""
+
+        if hasattr(self.retriever, "retrieve"):
+            mem_vec = self.retriever.retrieve(dialogue_id, speaker)
+            if mem_vec is None:
+                return hidden_states
+            return hidden_states + mem_vec
 
         memory = self.retriever.last_message(dialogue_id, speaker)
         if not memory:


### PR DESCRIPTION
## Summary
- implement policy-gradient `ReinforceRetriever` for selecting memory nodes
- integrate retrieval probabilities into `MemoryAttention` cross-attention
- add demonstration of online reward updates in `pro_rag` training script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b28094514483298497fa8601a017e5