### PR TITLE
Add experimental quantum attention module

### DIFF
--- a/tests/quantum/test_quantum_attention.py
+++ b/tests/quantum/test_quantum_attention.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pathlib
+import sys
+
+# Allow imports from project root
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from transformers.quantum_attention import QuantumAttention
+
+
+def test_noise_robustness():
+    """Small noise should not drastically alter measurement outcomes."""
+    q = np.array([[1.0, 0.0]])
+    k = np.eye(2)
+    v = np.eye(2)
+    clean = QuantumAttention(noise=0.0, seed=0)
+    noisy = QuantumAttention(noise=0.2, seed=0)
+    amp_clean = clean.compute_amplitudes(q, k)
+    amp_noisy = noisy.compute_amplitudes(q, k)
+    res_clean = clean.measure(amp_clean, v)
+    res_noisy = noisy.measure(amp_noisy, v)
+    assert np.allclose(res_clean, res_noisy, atol=0.2)
+
+
+def test_superposition_learning():
+    """Queries spanning keys should return a balanced superposed output."""
+    q = np.array([[1.0, 1.0]])
+    k = np.eye(2)
+    v = np.eye(2)
+    qa = QuantumAttention()
+    amp = qa.compute_amplitudes(q, k)
+    res = qa.measure(amp, v)
+    expected = np.array([[0.5, 0.5]])
+    assert np.allclose(res, expected, atol=0.1)

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -1,3 +1,22 @@
 from .blocks import DynamicContextGate
+from .modeling_transformer import MemoryAttention
+from .quantum_attention import QuantumAttention
 
-__all__ = ["DynamicContextGate"]
+__all__ = ["DynamicContextGate", "MemoryAttention", "QuantumAttention", "get_attention"]
+
+
+def get_attention(kind: str):
+    """Return an attention class by *kind*.
+
+    Parameters
+    ----------
+    kind : str
+        ``"quantum"`` for :class:`QuantumAttention`, ``"memory"`` for
+        :class:`MemoryAttention`.
+    """
+
+    if kind == "quantum":
+        return QuantumAttention
+    if kind == "memory":
+        return MemoryAttention
+    raise ValueError(f"Unknown attention kind: {kind}")

--- a/transformers/quantum_attention.py
+++ b/transformers/quantum_attention.py
@@ -1,0 +1,58 @@
+"""Experimental quantum-inspired attention mechanism.
+
+This module simulates probability amplitudes and measurements to model a
+quantum-style attention.  It is purely a toy implementation intended for
+experiments and unit tests.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+class QuantumAttention:
+    """Simulate a minimal quantum attention mechanism.
+
+    Parameters
+    ----------
+    noise : float, optional
+        Standard deviation of complex gaussian noise applied to amplitudes.
+    seed : int, optional
+        Random seed for reproducibility.
+    """
+
+    def __init__(self, noise: float = 0.0, seed: int | None = None) -> None:
+        self.noise = noise
+        self.rng = np.random.default_rng(seed)
+
+    def compute_amplitudes(self, query: np.ndarray, key: np.ndarray) -> np.ndarray:
+        """Return normalised complex amplitudes for ``query`` and ``key``.
+
+        The amplitudes are derived from the scaled dot product between query and
+        key.  Complex gaussian noise can be injected to simulate decoherence.
+        """
+
+        scores = np.dot(query, key.T) / np.sqrt(key.shape[-1])
+        amplitudes = np.exp(1j * scores)
+        if self.noise:
+            noise = self.noise * (
+                self.rng.normal(size=amplitudes.shape)
+                + 1j * self.rng.normal(size=amplitudes.shape)
+            )
+            amplitudes = amplitudes + noise
+        # Normalise along the last axis
+        norm = np.linalg.norm(amplitudes, axis=-1, keepdims=True)
+        # Avoid division by zero
+        norm = np.where(norm == 0, 1, norm)
+        return amplitudes / norm
+
+    def measure(self, amplitudes: np.ndarray, value: np.ndarray) -> np.ndarray:
+        """Collapse ``amplitudes`` and return classical output.
+
+        Probabilities are obtained by squaring the magnitude of the complex
+        amplitudes.  These probabilities are used to take the expected value over
+        ``value``.
+        """
+
+        probs = np.abs(amplitudes) ** 2
+        probs = probs / probs.sum(axis=-1, keepdims=True)
+        return probs @ value


### PR DESCRIPTION
## Summary
- add quantum-inspired attention module that simulates amplitudes and measurement
- expose option to choose quantum attention via `get_attention`
- add experimental tests showcasing noise robustness and superposition learning

## Testing
- `ruff check transformers/quantum_attention.py transformers/__init__.py tests/quantum/test_quantum_attention.py`
- `pytest tests/quantum/test_quantum_attention.py -q`

_This PR is experimental._

------
https://chatgpt.com/codex/tasks/task_e_68b28512e71083299f8151e4301dea8b