### PR TITLE
Add time folding transformer with quantum memory support

### DIFF
--- a/docs/time_fold_demo.ipynb
+++ b/docs/time_fold_demo.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Time Fold Demo\n",
+    "\n",
+    "Demonstrates forward-ahead prediction and reverse-time gradient echo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from transformers.time_fold import TimeFoldTransformer\n",
+    "from quantum_memory import QuantumMemory\n",
+    "\n",
+    "def step(x):\n",
+    "    return x + 1\n",
+    "\n",
+    "tf = TimeFoldTransformer(step, steps=2, memory=QuantumMemory())\n",
+    "out = tf.forward(np.array([0.0]))\n",
+    "grad = tf.echo_backward(np.array([1.0]))\n",
+    "out, grad"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/quantum_memory.py
+++ b/quantum_memory.py
@@ -1,0 +1,34 @@
+"""Amplitude-based memory for storing future states.
+
+This module provides :class:`QuantumMemory`, a minimal container that keeps
+complex amplitude vectors for a sequence of future time steps.  The memory is
+indexed by step number and can be retrieved later when performing reverse-time
+updates.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+
+
+class QuantumMemory:
+    """Store complex amplitudes for discrete time steps."""
+
+    def __init__(self) -> None:
+        self.amplitudes: Dict[int, np.ndarray] = {}
+
+    def store(self, step: int, amps: np.ndarray) -> None:
+        """Store ``amps`` for ``step``."""
+
+        self.amplitudes[step] = amps
+
+    def retrieve(self, step: int) -> np.ndarray | None:
+        """Return stored amplitudes for ``step`` if present."""
+
+        return self.amplitudes.get(step)
+
+    def clear(self) -> None:
+        """Remove all stored amplitudes."""
+
+        self.amplitudes.clear()

--- a/trainer.py
+++ b/trainer.py
@@ -1,5 +1,8 @@
-"""Simple training loop with layer evaluation."""
+"""Simple training loop with layer evaluation and time folding."""
 from autoadapt import LayerMutator, MetricMonitor
+import numpy as np
+from quantum_memory import QuantumMemory
+from transformers.time_fold import TimeFoldTransformer
 
 
 class Trainer:
@@ -9,16 +12,20 @@ class Trainer:
         self,
         eval_interval: int = 10,
         checkpoint_dir: str = "checkpoints/autoadapt",
+        time_fold_steps: int = 1,
     ) -> None:
         self.eval_interval = eval_interval
         self.monitor = MetricMonitor()
         self.mutator = LayerMutator()
         self.step = 0
         self.checkpoint_dir = checkpoint_dir
+        self.time_fold_steps = time_fold_steps
 
     def train_step(self, layer: str, metric: float) -> None:
         """Simulate a training step and record metric for ``layer``."""
         self.monitor.record(metric)
+        if self.time_fold_steps > 1:
+            self._gradient_echo(metric)
         self.step += 1
         if self.step % self.eval_interval == 0:
             self._evaluate(layer)
@@ -29,3 +36,12 @@ class Trainer:
             # Boost the layer slightly if performance is lacking
             self.mutator.mutate(layer, 1.1)
             self.mutator.save(self.checkpoint_dir)
+
+    # Time folding ------------------------------------------------------
+    def _gradient_echo(self, value: float) -> None:
+        """Propagate a dummy gradient through future predictions."""
+
+        tf = TimeFoldTransformer(lambda x: x, self.time_fold_steps, QuantumMemory())
+        arr = np.array([value], dtype=np.float32)
+        tf.forward(arr)
+        tf.echo_backward(np.ones_like(arr))

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -1,8 +1,15 @@
 from .blocks import DynamicContextGate
 from .modeling_transformer import MemoryAttention
 from .quantum_attention import QuantumAttention
+from .time_fold import TimeFoldTransformer
 
-__all__ = ["DynamicContextGate", "MemoryAttention", "QuantumAttention", "get_attention"]
+__all__ = [
+    "DynamicContextGate",
+    "MemoryAttention",
+    "QuantumAttention",
+    "TimeFoldTransformer",
+    "get_attention",
+]
 
 
 def get_attention(kind: str):

--- a/transformers/time_fold.py
+++ b/transformers/time_fold.py
@@ -1,0 +1,49 @@
+"""Time folding transformer that looks ahead and updates backwards.
+
+The :class:`TimeFoldTransformer` runs a provided step function forward a number
+of steps, caching each intermediate prediction.  Amplitude vectors are stored in
+a :class:`~quantum_memory.QuantumMemory` so that reverse-time gradient updates
+can be computed later via :meth:`echo_backward`.
+"""
+from __future__ import annotations
+
+from typing import Callable, List
+
+import numpy as np
+
+from quantum_memory import QuantumMemory
+
+
+class TimeFoldTransformer:
+    """Run forward for multiple future steps and support reverse updates."""
+
+    def __init__(
+        self,
+        step_fn: Callable[[np.ndarray], np.ndarray],
+        steps: int,
+        memory: QuantumMemory | None = None,
+    ) -> None:
+        self.step_fn = step_fn
+        self.steps = steps
+        self.memory = memory or QuantumMemory()
+        self.cache: List[np.ndarray] = []
+
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        """Run ``step_fn`` forward ``steps`` times storing predictions."""
+
+        self.cache = []
+        out = x
+        for i in range(self.steps):
+            out = self.step_fn(out)
+            self.cache.append(out)
+            self.memory.store(i, out.astype(np.complex128))
+        return out
+
+    def echo_backward(self, grad: np.ndarray) -> np.ndarray:
+        """Propagate ``grad`` backwards using stored amplitudes."""
+
+        for i in reversed(range(self.steps)):
+            amps = self.memory.retrieve(i)
+            if amps is not None:
+                grad = grad * np.conj(amps).real
+        return grad


### PR DESCRIPTION
## Summary
- implement `QuantumMemory` for amplitude storage of future states
- add `TimeFoldTransformer` with forward caching and reverse-time gradient echo
- extend `Trainer` with `time_fold_steps` and gradient echo logic
- include demo notebook for time folding

## Testing
- `flake8 quantum_memory.py transformers/time_fold.py transformers/__init__.py trainer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2883c680883298aa731dceebd5fd4