### PR TITLE
Disallow possessive pronoun sentence endings

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -34,6 +34,8 @@ HASH_PATH = 'dataset_sha.json'
 LOG_PATH = 'pro.log'
 TUNE_CONCURRENCY = 4
 
+FORBIDDEN_ENDINGS = {"the", "a", "and", "or", "his", "my", "their"}
+
 
 class ProEngine:
     def __init__(
@@ -636,12 +638,12 @@ class ProEngine:
             words2[0] = first2
             sentence2 = " ".join(filter(None, words2[:target_length2])) + "."
             last1 = sentence1.rstrip(".").split()[-1].lower()
-            if last1 in {"the", "a", "and", "or"}:
+            if last1 in FORBIDDEN_ENDINGS:
                 replacement = next(
                     (
                         w
                         for w in ordered
-                        if w.lower() not in {"the", "a", "and", "or"}
+                        if w.lower() not in FORBIDDEN_ENDINGS
                     ),
                     last1,
                 )
@@ -650,12 +652,12 @@ class ProEngine:
                 sentence1 = " ".join(parts) + "."
 
             last2 = sentence2.rstrip(".").split()[-1].lower()
-            if last2 in {"the", "a", "and", "or"}:
+            if last2 in FORBIDDEN_ENDINGS:
                 replacement2 = next(
                     (
                         w
                         for w in ordered2
-                        if w.lower() not in {"the", "a", "and", "or"}
+                        if w.lower() not in FORBIDDEN_ENDINGS
                     ),
                     last2,
                 )

--- a/tests/test_possessive_endings.py
+++ b/tests/test_possessive_endings.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import pro_engine
+import pro_predict
+
+
+def test_sentences_do_not_end_with_possessive_pronouns(monkeypatch):
+    engine = pro_engine.ProEngine()
+    engine.state["word_counts"] = {"alpha": 5, "beta": 4, "gamma": 3}
+    engine.state["bigram_counts"] = {}
+    engine.state["trigram_counts"] = {}
+    engine.state["char_ngram_counts"] = {}
+    engine.state["trigram_inv"] = {}
+    engine.state["bigram_inv"] = {}
+    engine.state["word_inv"] = {}
+
+    monkeypatch.setattr(pro_predict, "lookup_analogs", lambda w: w)
+    monkeypatch.setattr(pro_predict, "_ensure_vectors", lambda: None)
+    pro_predict._VECTORS = {w: {w: 1.0} for w in engine.state["word_counts"]}
+
+    def fake_plan_sentence(self, initial, target_length, **kwargs):
+        count = getattr(self, "_calls", 0) + 1
+        self._calls = count
+        if count == 1:
+            return ["alpha"] * (target_length - 1) + ["my"]
+        return ["beta"] * (target_length - 1) + ["their"]
+
+    monkeypatch.setattr(pro_engine.ProEngine, "plan_sentence", fake_plan_sentence, raising=False)
+
+    sentence = asyncio.run(engine.respond(["seed"]))
+    first, second = sentence.split(". ")
+    assert first.split()[-1].lower() not in {"his", "my", "their"}
+    assert second.rstrip(".").split()[-1].lower() not in {"his", "my", "their"}


### PR DESCRIPTION
## Summary
- prevent generated sentences from ending with possessive pronouns by expanding the forbidden endings set
- replace disallowed endings in both sentences using the unified set of forbidden words
- add regression test ensuring neither sentence ends with "his", "my", or "their"

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b28a585bfc8329983de45765e3856a