### PR TITLE
Add configurable LoRA layer persistence with example fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,29 @@ With modular design and measured feedback, the RE is positioned for rapid expans
 | Single Adapter  |       42.1 |                110 |
 | MoE (2 adapters)|       30.5 |                 90 |
 
+## Personal Fine-Tuning with LoRA
+
+LoRA adapters can be enabled by setting ``use_lora`` in the training
+configuration.  The snippet below demonstrates how to fine-tune and persist
+personal adapters:
+
+```python
+from autoadapt import LayerMutator, LoRALayer
+from trainer import Trainer
+
+trainer = Trainer(use_lora=True)
+layer = LoRALayer(
+    name="greeting",
+    rank=2,
+    alpha=1.0,
+    matrix_a=[[0.0, 0.0], [0.0, 0.0]],
+    matrix_b=[[0.0, 0.0], [0.0, 0.0]],
+)
+trainer.mutator.add_lora_layer(layer)
+trainer.mutator.save("checkpoints/my_lora")
+```
+
+Saved adapters can later be reloaded with
+``LayerMutator.load("checkpoints/my_lora")`` for continued training or
+inference.
+

--- a/adapter_pool/greetings/config.json
+++ b/adapter_pool/greetings/config.json
@@ -1,5 +1,6 @@
 {
   "name": "greetings",
   "keywords": ["hello", "hi"],
-  "weights_path": "weights.json"
+  "weights_path": "weights.json",
+  "use_lora": false
 }

--- a/adapter_pool/science/config.json
+++ b/adapter_pool/science/config.json
@@ -1,5 +1,6 @@
 {
   "name": "science",
   "keywords": ["science", "physics"],
-  "weights_path": "weights.json"
+  "weights_path": "weights.json",
+  "use_lora": false
 }

--- a/autoadapt/__init__.py
+++ b/autoadapt/__init__.py
@@ -1,25 +1,87 @@
 import json
 import os
+from dataclasses import asdict, dataclass
 from typing import Dict, List
 
 
-class LayerMutator:
-    """Track and persist layer modifications."""
+@dataclass
+class LoRALayer:
+    """Minimal representation of a LoRA adapter layer."""
 
-    def __init__(self) -> None:
+    name: str
+    rank: int
+    alpha: float
+    matrix_a: List[List[float]]
+    matrix_b: List[List[float]]
+
+    def save(self, path: str) -> None:
+        """Serialize layer parameters to *path* as JSON."""
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(asdict(self), fh)
+
+    @classmethod
+    def load(cls, path: str) -> "LoRALayer":
+        """Load layer parameters from *path*."""
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return cls(**data)
+
+
+class LayerMutator:
+    """Track and persist layer modifications and optional LoRA adapters."""
+
+    def __init__(self, use_lora: bool = False) -> None:
         self.mutations: Dict[str, float] = {}
+        self.use_lora = use_lora
+        self.lora_layers: Dict[str, LoRALayer] = {}
 
     def mutate(self, layer: str, factor: float) -> None:
         """Apply a simple multiplicative mutation to a layer."""
         current = self.mutations.get(layer, 1.0)
         self.mutations[layer] = current * factor
 
+    # -- LoRA -----------------------------------------------------------
+    def add_lora_layer(self, layer: LoRALayer) -> None:
+        """Register a :class:`LoRALayer` for persistence."""
+        if self.use_lora:
+            self.lora_layers[layer.name] = layer
+
+    def save_lora(self, directory: str) -> None:
+        """Save all registered LoRA layers to *directory*."""
+        if not self.use_lora or not self.lora_layers:
+            return
+        os.makedirs(directory, exist_ok=True)
+        for layer in self.lora_layers.values():
+            path = os.path.join(directory, f"{layer.name}.json")
+            layer.save(path)
+
+    def load_lora(self, directory: str) -> None:
+        """Load LoRA layers from *directory* if present."""
+        if not self.use_lora or not os.path.isdir(directory):
+            return
+        for fname in os.listdir(directory):
+            if fname.endswith(".json"):
+                layer = LoRALayer.load(os.path.join(directory, fname))
+                self.lora_layers[layer.name] = layer
+
+    # -- Persistence ----------------------------------------------------
     def save(self, directory: str) -> None:
         """Persist mutation state to ``directory``."""
         os.makedirs(directory, exist_ok=True)
         path = os.path.join(directory, "mutations.json")
         with open(path, "w", encoding="utf-8") as fh:
             json.dump(self.mutations, fh)
+        if self.use_lora:
+            self.save_lora(os.path.join(directory, "lora"))
+
+    def load(self, directory: str) -> None:
+        """Load mutation state and LoRA layers from ``directory``."""
+        path = os.path.join(directory, "mutations.json")
+        if os.path.isfile(path):
+            with open(path, "r", encoding="utf-8") as fh:
+                self.mutations = json.load(fh)
+        if self.use_lora:
+            self.load_lora(os.path.join(directory, "lora"))
 
 
 class MetricMonitor:

--- a/tests/test_lora_layers.py
+++ b/tests/test_lora_layers.py
@@ -1,0 +1,21 @@
+from autoadapt import LayerMutator, LoRALayer
+
+
+def test_lora_save_and_load(tmp_path):
+    mut = LayerMutator(use_lora=True)
+    layer = LoRALayer(
+        name="dense",
+        rank=2,
+        alpha=1.0,
+        matrix_a=[[1.0, 0.0], [0.0, 1.0]],
+        matrix_b=[[0.5, 0.0], [0.0, 0.5]],
+    )
+    mut.add_lora_layer(layer)
+    mut.save(tmp_path)
+
+    mut2 = LayerMutator(use_lora=True)
+    mut2.load(tmp_path)
+    assert "dense" in mut2.lora_layers
+    loaded = mut2.lora_layers["dense"]
+    assert loaded.matrix_a == layer.matrix_a
+    assert loaded.matrix_b == layer.matrix_b

--- a/trainer.py
+++ b/trainer.py
@@ -13,10 +13,13 @@ class Trainer:
         eval_interval: int = 10,
         checkpoint_dir: str = "checkpoints/autoadapt",
         time_fold_steps: int = 1,
+        use_lora: bool = False,
     ) -> None:
         self.eval_interval = eval_interval
         self.monitor = MetricMonitor()
-        self.mutator = LayerMutator()
+        self.mutator = LayerMutator(use_lora=use_lora)
+        if use_lora:
+            self.mutator.load(checkpoint_dir)
         self.step = 0
         self.checkpoint_dir = checkpoint_dir
         self.time_fold_steps = time_fold_steps


### PR DESCRIPTION
## Summary
- support saving and loading LoRA adapters through `LayerMutator`
- add `use_lora` configuration toggle and default configs
- document how to fine-tune personal adapters with LoRA
- cover LoRA persistence with a focused unit test

## Testing
- `flake8` *(fails: many style violations across repository)*
- `PYTHONPATH=. pytest tests/test_lora_layers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b28db255648329bae1780762839b99