### PR TITLE
feat: allow custom memory kernels

### DIFF
--- a/tests/test_memory_kernel.py
+++ b/tests/test_memory_kernel.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from transformers.modeling_transformer import MemoryAttention, register_kernel
+
+
+class DummyRetriever:
+    def __init__(self, dim: int):
+        self.dim = dim
+
+    def retrieve(self, dialogue_id, speaker):
+        return np.ones(self.dim, dtype=np.float32)
+
+
+def test_custom_memory_kernel_executes_and_resets():
+    dim = 4
+    hidden = np.ones(dim, dtype=np.float32)
+    retriever = DummyRetriever(dim)
+    register_kernel("lambda h, m: h * 0.5 + m")
+    attn = MemoryAttention(retriever, dim=dim)
+    out = attn(hidden, "d", "s")
+    assert np.allclose(out, hidden * 0.5 + np.ones(dim))
+    # Clean up so subsequent tests use default behaviour
+    register_kernel(None)

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -1,11 +1,12 @@
 from .blocks import DynamicContextGate
-from .modeling_transformer import MemoryAttention
+from .modeling_transformer import MemoryAttention, register_kernel
 from .quantum_attention import QuantumAttention
 from .time_fold import TimeFoldTransformer
 
 __all__ = [
     "DynamicContextGate",
     "MemoryAttention",
+    "register_kernel",
     "QuantumAttention",
     "TimeFoldTransformer",
     "get_attention",


### PR DESCRIPTION
## Summary
- allow registering memory kernels with sanitization
- execute registered kernels in MemoryAttention
- cover custom kernels with tests

## Testing
- `flake8 transformers/modeling_transformer.py transformers/__init__.py tests/test_memory_kernel.py`
- `PYTHONPATH=. pytest tests/test_memory_kernel.py tests/test_transformer_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34878c0488329bd487cb7b3f0f3da