### PR TITLE
Integrate memory vector into quantum attention

### DIFF
--- a/transformers/modeling_transformer.py
+++ b/transformers/modeling_transformer.py
@@ -21,6 +21,8 @@ import morphology
 
 from memory.memory_graph import GraphRetriever
 from memory.reinforce_retriever import ReinforceRetriever
+from .quantum_attention import QuantumAttention
+from .quantum_memory_attention import QuantumMemoryAttention
 
 
 _kernel: Optional[Callable[[np.ndarray, np.ndarray], np.ndarray]] = None
@@ -183,3 +185,22 @@ class QuantumHybridAttention:
                     query[idx], key, value
                 )
         return out
+
+
+class QuantumMemoryLayer:
+    """Integrate retrieved memory into a quantum attention step."""
+
+    def __init__(
+        self, retriever: ReinforceRetriever, backend: QuantumAttention | None = None
+    ) -> None:
+        self.attention = QuantumMemoryAttention(retriever, backend)
+
+    def __call__(
+        self,
+        query: np.ndarray,
+        key: np.ndarray,
+        value: np.ndarray,
+        dialogue_id: str,
+        speaker: str,
+    ) -> np.ndarray:
+        return self.attention.attention(query, key, value, dialogue_id, speaker)

--- a/transformers/quantum_memory_attention.py
+++ b/transformers/quantum_memory_attention.py
@@ -1,0 +1,48 @@
+"""Quantum attention incorporating retrieved memory vectors."""
+from __future__ import annotations
+
+import numpy as np
+
+from memory.reinforce_retriever import ReinforceRetriever
+from .quantum_attention import QuantumAttention
+
+
+class QuantumMemoryAttention:
+    """Combine quantum amplitudes with a retrieved memory vector.
+
+    The class first computes standard quantum amplitudes between ``query`` and
+    ``key`` using :class:`QuantumAttention`.  A second set of amplitudes is
+    derived from a memory vector obtained via
+    :class:`~memory.reinforce_retriever.ReinforceRetriever.retrieve`.  The two
+    complex amplitudes are added, strengthening phases when memory and key
+    align.
+    """
+
+    def __init__(
+        self, retriever: ReinforceRetriever, backend: QuantumAttention | None = None
+    ) -> None:
+        self.retriever = retriever
+        self.backend = backend or QuantumAttention()
+
+    def compute_amplitudes(
+        self, query: np.ndarray, key: np.ndarray, dialogue_id: str, speaker: str
+    ) -> np.ndarray:
+        """Return amplitudes from keys and retrieved memory."""
+
+        mem_vec = self.retriever.retrieve(dialogue_id, speaker)
+        amp_key = self.backend.compute_amplitudes(query, key)
+        amp_mem = self.backend.compute_amplitudes(query, mem_vec[None, :])
+        return amp_key + amp_mem
+
+    def attention(
+        self,
+        query: np.ndarray,
+        key: np.ndarray,
+        value: np.ndarray,
+        dialogue_id: str,
+        speaker: str,
+    ) -> np.ndarray:
+        """Return attention output enriched with memory phases."""
+
+        amp = self.compute_amplitudes(query, key, dialogue_id, speaker)
+        return self.backend.measure(amp, value)


### PR DESCRIPTION
## Summary
- add QuantumMemoryAttention that fuses key amplitudes with a memory vector
- expose QuantumMemoryLayer in modeling_transformer for combined phase attention
- test that matching key and memory amplifies quantum amplitudes

## Testing
- `pytest tests/quantum/test_quantum_attention.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34c78adac8329a180a7625d06c4d8