### PR TITLE
Integrate lattice embeddings for graph-aware retrieval

### DIFF
--- a/memory/memory_lattice.py
+++ b/memory/memory_lattice.py
@@ -1,0 +1,80 @@
+"""Graph-based memory store with embeddings.
+
+This is an extension of :mod:`memory_graph` where each node stores an
+additional embedding vector.  The structure remains a simple mapping from
+``dialogue_id`` to a list of nodes, but embeddings allow vector based
+retrieval in combination with structural relations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+import json
+import os
+from typing import Dict, List, Optional
+
+
+@dataclass
+class MemoryNode:
+    """Single utterance with an embedding."""
+
+    speaker: str
+    text: str
+    embedding: Dict[str, float]
+
+
+class MemoryGraphStore:
+    """Store dialogues as simple graphs with vector representations."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self.path = path
+        self.graph: Dict[str, List[MemoryNode]] = {}
+        if path and os.path.exists(path):
+            self.load(path)
+
+    def add_utterance(
+        self,
+        dialogue_id: str,
+        speaker: str,
+        text: str,
+        embedding: Dict[str, float],
+    ) -> None:
+        """Append an utterance with ``embedding`` to a dialogue."""
+
+        self.graph.setdefault(dialogue_id, []).append(
+            MemoryNode(speaker, text, embedding)
+        )
+        if self.path:
+            self.save(self.path)
+
+    def get_dialogue(self, dialogue_id: str) -> List[MemoryNode]:
+        """Return the list of nodes for ``dialogue_id``."""
+
+        return list(self.graph.get(dialogue_id, []))
+
+    def all_nodes(self) -> List[MemoryNode]:
+        """Return a flat list of all nodes across dialogues."""
+
+        return [node for nodes in self.graph.values() for node in nodes]
+
+    # Persistence -------------------------------------------------------
+    def save(self, path: Optional[str] = None) -> None:
+        path = path or self.path
+        if not path:
+            return
+        data = {
+            did: [asdict(node) for node in nodes]
+            for did, nodes in self.graph.items()
+        }
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False)
+        self.path = path
+
+    def load(self, path: str) -> None:
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+        self.graph = {
+            did: [MemoryNode(**node) for node in nodes]
+            for did, nodes in raw.items()
+        }
+        self.path = path

--- a/tests/test_memory_lattice_retrieve.py
+++ b/tests/test_memory_lattice_retrieve.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from pro_metrics import tokenize, lowercase  # noqa: E402
+import pro_memory  # noqa: E402
+import pro_rag  # noqa: E402
+from memory.memory_lattice import MemoryGraphStore  # noqa: E402
+import pro_predict  # noqa: E402
+
+
+def _embed(text: str) -> dict:
+    words = lowercase(tokenize(text))
+    return pro_rag._sentence_vector(words)
+
+
+@pytest.mark.asyncio
+async def test_retrieve_uses_graph_and_embedding(monkeypatch):
+    monkeypatch.setattr(
+        pro_predict, "_VECTORS", {"dogs": {"d": 1.0}, "cats": {"c": 1.0}}
+    )
+    store = MemoryGraphStore()
+    store.add_utterance("d1", "user", "cats eat fish", _embed("cats eat fish"))
+    store.add_utterance(
+        "d1", "user", "dogs chase cats", _embed("dogs chase cats")
+    )
+
+    async def fake_related(words):
+        return []
+
+    monkeypatch.setattr(pro_memory, "fetch_related_concepts", fake_related)
+
+    results = await pro_rag.retrieve(["dogs"], lattice=store, limit=2)
+    assert results[0] == "dogs chase cats"
+    assert "cats eat fish" in results


### PR DESCRIPTION
## Summary
- Add `memory_lattice` store that keeps per-node embeddings with persistence
- Enhance `pro_rag.retrieve` to leverage lattice embeddings and graph neighbours
- Test retrieval combines vector similarity with structural context

## Testing
- `flake8 memory/memory_lattice.py pro_rag.py tests/test_memory_lattice_retrieve.py`
- `pytest tests/test_memory_lattice_retrieve.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b351e9b4d88329b9bcddbc5ec7d7be