### PR TITLE
Resonant LRA for MemoryAttention

### DIFF
--- a/tests/attention/test_dynamic_context_gate.py
+++ b/tests/attention/test_dynamic_context_gate.py
@@ -3,7 +3,11 @@ import pathlib
 import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
-from pro_predict import MiniSelfAttention
+from pro_predict import MiniSelfAttention  # noqa: E402
+from transformers.modeling_transformer import (  # noqa: E402
+    MemoryAttention,
+    ResonantAdapter,
+)
 
 
 def test_gate_can_zero_context():
@@ -19,3 +23,15 @@ def test_gate_can_zero_context():
     model.gate.bias = np.full(model.dim, 100.0)
     boosted = model.logits(tokens)
     assert any(abs(boosted[w]) > abs(baseline[w]) for w in vocab)
+
+
+def test_resonant_adapter_adds_signal():
+    class EmptyRetriever:
+        def last_message(self, dialogue_id, speaker):
+            return None
+
+    attention = MemoryAttention(EmptyRetriever(), dim=4)
+    hidden = np.zeros(4, dtype=np.float32)
+    out = attention(hidden, "d", "s")
+    expected = ResonantAdapter(1.0, 0.1)(4)
+    assert np.allclose(out, expected)


### PR DESCRIPTION
## Summary
- add ResonantAdapter sinusoidal module
- integrate resonant adapter into MemoryAttention
- cover adapter behavior with unit tests

## Testing
- `python -m flake8 transformers/modeling_transformer.py tests/attention/test_dynamic_context_gate.py --count`
- `pytest tests/attention/test_dynamic_context_gate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3599511ac832988d79a948429beb7