### PR TITLE
Integrate forecast retrocausality into training loop

### DIFF
--- a/tests/test_forecast_retrocausality.py
+++ b/tests/test_forecast_retrocausality.py
@@ -1,0 +1,26 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pro_forecast
+import pro_predict
+
+
+def test_forecast_retrocausality(monkeypatch):
+    vocab = ["alpha", "beta", "gamma"]
+    monkeypatch.setattr(pro_predict, "_VECTORS", {w: {} for w in vocab}, raising=False)
+    monkeypatch.setattr(pro_predict, "_GRAPH", {w: {} for w in vocab}, raising=False)
+    monkeypatch.setattr(pro_predict, "_TRANSFORMERS", {}, raising=False)
+    monkeypatch.setattr(pro_predict, "_ensure_vectors", lambda: None, raising=False)
+
+    root = pro_forecast.simulate_paths(["alpha"], depth=1)
+    low_branch = min(root.children, key=lambda n: n.prob)
+    target_word = low_branch.text.split()[-1]
+    before = low_branch.prob
+
+    pro_forecast.backpropagate_forecast(low_branch)
+
+    root_after = pro_forecast.simulate_paths(["alpha"], depth=1)
+    after = next(n.prob for n in root_after.children if n.text.endswith(target_word))
+    assert after > before

--- a/trainer.py
+++ b/trainer.py
@@ -3,6 +3,7 @@ from autoadapt import LayerMutator, MetricMonitor
 import numpy as np
 from quantum_memory import QuantumMemory
 from transformers.time_fold import TimeFoldTransformer
+from pro_forecast import simulate_paths, backpropagate_forecast
 
 
 class Trainer:
@@ -26,6 +27,8 @@ class Trainer:
 
     def train_step(self, layer: str, metric: float) -> None:
         """Simulate a training step and record metric for ``layer``."""
+        forecast = simulate_paths([layer])
+        backpropagate_forecast(forecast)
         self.monitor.record(metric)
         if self.time_fold_steps > 1:
             self._gradient_echo(metric)


### PR DESCRIPTION
## Summary
- add `backpropagate_forecast` to translate forecast novelty into weight updates
- call forecasting simulation before each training step so retrocausal gradients affect metrics and layer mutations
- test that unexpected branches become more likely on subsequent predictions

## Testing
- `python -m py_compile pro_forecast.py trainer.py tests/test_forecast_retrocausality.py`
- `flake8 pro_forecast.py trainer.py tests/test_forecast_retrocausality.py` *(fails: command not found)*
- `pytest tests/test_forecast_retrocausality.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b35a884e9c83299bd615b76984a7c5