### PR TITLE
Add morpheme hashing encoder and tests

### DIFF
--- a/memory/memory_graph.py
+++ b/memory/memory_graph.py
@@ -14,10 +14,12 @@ its state to disk via JSON serialization.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, field, asdict
 import json
 import os
 from typing import Dict, List, Optional
+
+from morphology import encode as encode_morph
 
 
 @dataclass
@@ -26,6 +28,7 @@ class MemoryNode:
 
     speaker: str
     text: str
+    morph_codes: List[float] = field(default_factory=list)
 
 
 class MemoryGraphStore:
@@ -40,7 +43,10 @@ class MemoryGraphStore:
     def add_utterance(self, dialogue_id: str, speaker: str, text: str) -> None:
         """Append an utterance to a dialogue and persist to disk."""
 
-        self.graph.setdefault(dialogue_id, []).append(MemoryNode(speaker, text))
+        codes = encode_morph(text).tolist()
+        self.graph.setdefault(dialogue_id, []).append(
+            MemoryNode(speaker, text, codes)
+        )
         if self.path:
             self.save(self.path)
 


### PR DESCRIPTION
## Summary
- extend MemoryNode with stored morpheme codes
- encode memory texts via morpheme hashing in ReinforceRetriever
- add lightweight morphology tokenizer and encoder with tests

## Testing
- `ruff check memory/memory_graph.py memory/reinforce_retriever.py morphology.py tests/test_memory_vectors.py`
- `pytest tests/test_memory_vectors.py`


------
https://chatgpt.com/codex/tasks/task_e_68b35ba81be48329a860c5b1331240b4