### PR TITLE
Add grammar checks for article capitalization and pronoun usage

### DIFF
--- a/grammar_filters.py
+++ b/grammar_filters.py
@@ -9,6 +9,10 @@ ARTICLE_PAIR_RE = re.compile(r"\b(the|a|an) (the|a|an)\b", re.IGNORECASE)
 A_PREP_RE = re.compile(r"\ba (in|on|to|by|at|of)\b(?! \w)", re.IGNORECASE)
 DUP_WORD_RE = re.compile(r"\b(\w+)\b \1\b", re.IGNORECASE)
 SINGLE_LETTER_PAIR_RE = re.compile(r"\b\w\b \b\w\b")
+MID_SENTENCE_CAP_THE_RE = re.compile(r"(?<!^)(?<![.!?]\s)The\b")
+ARTICLE_PRONOUN_RE = re.compile(
+    r"\b(the|a)\s+(he|she|they|it)\b", re.IGNORECASE
+)
 
 DUP_WHITELIST = {"go", "no", "yeah"}
 VERB_SET = {
@@ -63,6 +67,10 @@ def passes_filters(text: str) -> bool:
         return False
     if A_PREP_RE.search(text):
         return False
+    if MID_SENTENCE_CAP_THE_RE.search(text):
+        return False
+    if ARTICLE_PRONOUN_RE.search(text):
+        return False
     for m in DUP_WORD_RE.finditer(text):
         word = m.group(1).lower()
         if word in DUP_WHITELIST:
@@ -76,7 +84,10 @@ def passes_filters(text: str) -> bool:
             continue
         return False
     if SENTENCE_END_PREP_RE.search(text):
-        _log("ending-preposition", SENTENCE_END_PREP_RE.search(text).group(0).split())
+        _log(
+            "ending-preposition",
+            SENTENCE_END_PREP_RE.search(text).group(0).split(),
+        )
     if TO_SEQ_RE.search(text):
         _log("to-sequence", TO_SEQ_RE.search(text).group(0).split())
     return True

--- a/tests/test_articles_and_pronouns.py
+++ b/tests/test_articles_and_pronouns.py
@@ -1,0 +1,14 @@
+import grammar_filters
+
+
+def test_capital_the_in_middle_is_rejected():
+    assert not grammar_filters.passes_filters("We saw The cat")
+
+
+def test_article_before_pronoun_is_rejected():
+    assert not grammar_filters.passes_filters("a she walked")
+    assert not grammar_filters.passes_filters("the it moved")
+
+
+def test_capital_the_at_start_is_allowed():
+    assert grammar_filters.passes_filters("The dog ran")


### PR DESCRIPTION
## Summary
- prohibit capitalized 'The' inside sentences
- reject phrases using 'the' or 'a' before pronouns
- test grammar filters for these article rules

## Testing
- `flake8 grammar_filters.py tests/test_articles_and_pronouns.py`
- `PYTHONPATH=. pytest tests/test_articles_and_pronouns.py`


------
https://chatgpt.com/codex/tasks/task_e_68b36cd5f4a88329b6570569ad961cc7