### PR TITLE
Add evolutionary mini-model distillation to trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ Rewards accumulate across many turns.
 Moving averages flag progress and dips. Sudden drops trigger reviews.
 Stable curves mean healthy learning.
 
+### Evolutionary Mini-Model Distillation
+
+Mini-models mutate layers and train on dialogue slices.
+If their metrics beat the main model, their weights distill back.
+Evolution proceeds without full retraining.
+
 ### LoRA Adapter Persistence
 
 Low rank deltas retain personal tweaks. Users can resume from the same state later.

--- a/pro_evo.py
+++ b/pro_evo.py
@@ -1,0 +1,27 @@
+from typing import Sequence
+from autoadapt import LayerMutator, MetricMonitor
+
+
+class MiniModel:
+    """Generate and evaluate a lightweight model variant."""
+
+    def __init__(self, layer: str, use_lora: bool = False) -> None:
+        self.layer = layer
+        self.mutator = LayerMutator(use_lora=use_lora)
+        self.monitor = MetricMonitor()
+        # Start with a small mutation to explore the space
+        self.mutator.mutate(layer, 0.9)
+
+    def train(self, dialogue_part: Sequence[str]) -> None:
+        """Record metrics for a slice of dialogue."""
+        for turn in dialogue_part:
+            metric = len(turn) / (len(turn) + 1)
+            self.monitor.record(metric)
+
+    def score(self) -> float:
+        """Return the average metric for the mini-model."""
+        return self.monitor.average()
+
+    def distill(self, target: LayerMutator) -> None:
+        """Copy learned mutations into ``target``."""
+        target.mutations.update(self.mutator.mutations)

--- a/tests/test_evo_distillation.py
+++ b/tests/test_evo_distillation.py
@@ -1,0 +1,8 @@
+from trainer import Trainer
+
+
+def test_mini_model_distillation() -> None:
+    trainer = Trainer()
+    dialogue = ["hello", "there", "general", "kenobi"]
+    trainer.evolve("layer_x", dialogue, metric=0.9)
+    assert "layer_x" in trainer.mutator.mutations


### PR DESCRIPTION
## Summary
- introduce `pro_evo.MiniModel` for lightweight layer mutations and metric tracking
- add `Trainer.evolve` mode that distills improved mini-model weights
- document evolutionary distillation loop in README and add regression test

## Testing
- `flake8 pro_evo.py trainer.py tests/test_evo_distillation.py`
- `PYTHONPATH=. pytest tests/test_evo_distillation.py`
- `PYTHONPATH=. pytest tests/test_memory_kernel.py` *(fails: assert np.allclose(out, hidden * 0.5 + np.ones(dim)))*

------
https://chatgpt.com/codex/tasks/task_e_68b36b1f68988329bf1692a01468dba0