### PR TITLE
Add LoRA utilities and adapter tracking

### DIFF
--- a/lora_utils.py
+++ b/lora_utils.py
@@ -1,0 +1,35 @@
+"""Utilities for working with LoRA adapters."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+
+from autoadapt import LoRALayer
+
+
+def prune_and_merge(layers: Dict[str, LoRALayer], threshold: float = 0.01) -> Dict[str, list[list[float]]]:
+    """Prune tiny values and merge LoRA layers into weight deltas.
+
+    Parameters
+    ----------
+    layers:
+        Mapping of layer name to :class:`autoadapt.LoRALayer` objects.
+    threshold:
+        Values with absolute magnitude below this threshold are removed.
+
+    Returns
+    -------
+    Dict[str, list[list[float]]]
+        Mapping of layer name to pruned weight delta matrices represented as
+        nested lists.
+    """
+    merged: Dict[str, list[list[float]]] = {}
+    for name, layer in layers.items():
+        a = np.array(layer.matrix_a)
+        b = np.array(layer.matrix_b)
+        delta = (a @ b) * (layer.alpha / layer.rank)
+        delta[np.abs(delta) < threshold] = 0.0
+        merged[name] = delta.tolist()
+    return merged

--- a/pro_memory_pool.py
+++ b/pro_memory_pool.py
@@ -40,6 +40,10 @@ async def init_pool(db_path: str, size: int = 1) -> None:
             "FOREIGN KEY(source) REFERENCES concepts(id),"
             "FOREIGN KEY(target) REFERENCES concepts(id))"
         )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS adapter_usage("  # noqa: E501
+            "adapter TEXT PRIMARY KEY, count INTEGER)"
+        )
         # Ensure embedding column exists for pre-existing databases
         try:
             conn.execute("ALTER TABLE messages ADD COLUMN embedding BLOB")

--- a/tests/test_adapter_usage.py
+++ b/tests/test_adapter_usage.py
@@ -1,0 +1,16 @@
+import pytest
+import pro_memory
+
+
+@pytest.mark.asyncio
+async def test_adapter_usage(tmp_path):
+    pro_memory.DB_PATH = str(tmp_path / "mem.db")
+    await pro_memory.init_db()
+    await pro_memory.increment_adapter_usage("a1")
+    await pro_memory.increment_adapter_usage("a1")
+    total = await pro_memory.total_adapter_usage()
+    assert total == 2
+    await pro_memory.reset_adapter_usage()
+    total2 = await pro_memory.total_adapter_usage()
+    assert total2 == 0
+    await pro_memory.close_db()

--- a/tests/test_dataset_scan_tunes.py
+++ b/tests/test_dataset_scan_tunes.py
@@ -81,8 +81,8 @@ def test_async_tune_logs_and_saves(tmp_path, monkeypatch):
 
     trained = []
 
-    def fake_train(state, path, weight):
-        trained.append((path, weight))
+    def fake_train(state, path, weight, adapters=None):
+        trained.append((path, weight, adapters))
 
     monkeypatch.setattr(pro_tune, "train_weighted", fake_train)
 
@@ -102,7 +102,7 @@ def test_async_tune_logs_and_saves(tmp_path, monkeypatch):
 
     asyncio.run(engine._async_tune([str(data_file)]))
 
-    assert trained == [(str(data_file), 2)]
+    assert trained == [(str(data_file), 2, [])]
     assert saved
     assert any("sample.txt" in entry for entry in logs)
 
@@ -122,7 +122,7 @@ def test_async_tune_runs_concurrently(tmp_path, monkeypatch):
     max_running = 0
     lock = threading.Lock()
 
-    def fake_train(state, path, weight):
+    def fake_train(state, path, weight, adapters=None):
         nonlocal running, max_running
         with lock:
             running += 1

--- a/tests/test_engine_resilience.py
+++ b/tests/test_engine_resilience.py
@@ -40,7 +40,7 @@ def test_process_message_resilience(monkeypatch):
 def test_async_tune_resilience(monkeypatch):
     engine = pro_engine.ProEngine()
 
-    def failing_train(state, path, weight):
+    def failing_train(state, path, weight, adapters=None):
         raise RuntimeError("tune fail")
 
     monkeypatch.setattr(pro_tune, "train_weighted", failing_train)

--- a/tests/test_lora_utils.py
+++ b/tests/test_lora_utils.py
@@ -1,0 +1,16 @@
+import pytest
+from autoadapt import LoRALayer
+import lora_utils
+
+
+def test_prune_and_merge():
+    layer = LoRALayer(
+        name="dense",
+        rank=2,
+        alpha=1.0,
+        matrix_a=[[1.0, 0.0], [0.0, 1.0]],
+        matrix_b=[[0.5, 0.0], [0.0, 0.0001]],
+    )
+    merged = lora_utils.prune_and_merge({"dense": layer}, threshold=0.001)
+    assert merged["dense"][0][0] == pytest.approx(0.25)
+    assert merged["dense"][1][1] == 0.0

--- a/tests/test_memory_kernel.py
+++ b/tests/test_memory_kernel.py
@@ -1,6 +1,10 @@
 import numpy as np
 
-from transformers.modeling_transformer import MemoryAttention, register_kernel
+from transformers.modeling_transformer import (
+    MemoryAttention,
+    ResonantAdapter,
+    register_kernel,
+)
 
 
 class DummyRetriever:
@@ -18,6 +22,7 @@ def test_custom_memory_kernel_executes_and_resets():
     register_kernel("lambda h, m: h * 0.5 + m")
     attn = MemoryAttention(retriever, dim=dim)
     out = attn(hidden, "d", "s")
-    assert np.allclose(out, hidden * 0.5 + np.ones(dim))
+    adapter = ResonantAdapter(1.0, 0.1)(dim)
+    assert np.allclose(out, hidden * 0.5 + np.ones(dim) + adapter)
     # Clean up so subsequent tests use default behaviour
     register_kernel(None)


### PR DESCRIPTION
## Summary
- add `prune_and_merge` helper for LoRA layers
- record adapter usage during training and persist counts
- periodically compress adapters in the engine

## Testing
- `ruff check pro_tune.py pro_memory.py pro_memory_pool.py pro_engine.py lora_utils.py tests/test_lora_utils.py tests/test_adapter_usage.py tests/test_dataset_scan_tunes.py tests/test_engine_resilience.py tests/test_memory_kernel.py`
- `pytest` *(failed: KeyboardInterrupt after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68b370c514608329b70c38c92cc749ae