### PR TITLE
Add specialist spawning and knowledge distillation merge

### DIFF
--- a/pro_spawn.py
+++ b/pro_spawn.py
@@ -1,0 +1,32 @@
+import copy
+from typing import Dict
+
+from pro_tune import train
+
+
+def clone_weights(state: Dict) -> Dict:
+    """Deep-copy ``state`` to create an isolated clone of model weights."""
+    return copy.deepcopy(state)
+
+
+def fine_tune(state: Dict, dataset_path: str) -> Dict:
+    """Fine-tune *state* on data located at *dataset_path*.
+
+    Parameters
+    ----------
+    state:
+        Model state to update.
+    dataset_path:
+        Path to training dataset.
+    """
+    return train(state, dataset_path)
+
+
+def create_specialist(state: Dict, dataset_path: str) -> Dict:
+    """Clone ``state`` and fine-tune the clone on ``dataset_path``.
+
+    This utility is used to spawn a specialist model for a specific task or
+    topic.  The returned state is the tuned specialist.
+    """
+    specialist = clone_weights(state)
+    return fine_tune(specialist, dataset_path)


### PR DESCRIPTION
## Summary
- Add `pro_spawn` module to clone weights and fine-tune a specialist model
- Extend `ProEngine` with novelty-triggered specialist spawning and merging
- Introduce `merge_specialist` in `pro_tune` for knowledge distillation

## Testing
- `ruff check pro_spawn.py pro_engine.py pro_tune.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b37610c6708329bbcc3f8b8ab25383