### PR TITLE
Handle missing vector store gracefully

### DIFF
--- a/api/vector_store.py
+++ b/api/vector_store.py
@@ -5,7 +5,7 @@ import hashlib
 from typing import List
 from urllib import request
 
-DEFAULT_URL = os.getenv("VECTOR_STORE_URL", "http://localhost:8000")
+DEFAULT_URL = os.getenv("VECTOR_STORE_URL")
 
 async def upsert(text: str, embedding: List[float], base_url: str | None = None) -> None:
     """Store ``embedding`` for ``text`` in the external vector store.
@@ -14,7 +14,11 @@ async def upsert(text: str, embedding: List[float], base_url: str | None = None)
     endpoint accepting ``{"id": str, "embedding": List[float], "text": str}``.
     The call is executed in a thread to avoid blocking the event loop.
     """
-    url = f"{base_url or DEFAULT_URL}/upsert"
+    base_url = base_url or DEFAULT_URL
+    if not base_url:
+        return
+
+    url = f"{base_url}/upsert"
     payload = json.dumps({
         "id": hashlib.sha1(text.encode("utf-8")).hexdigest(),
         "embedding": embedding,
@@ -30,7 +34,11 @@ async def upsert(text: str, embedding: List[float], base_url: str | None = None)
 
 async def query(embedding: List[float], top_k: int = 5, base_url: str | None = None) -> List[str]:
     """Return texts most similar to ``embedding`` from the external store."""
-    url = f"{base_url or DEFAULT_URL}/query"
+    base_url = base_url or DEFAULT_URL
+    if not base_url:
+        return []
+
+    url = f"{base_url}/query"
     payload = json.dumps({"embedding": embedding, "top_k": top_k}).encode("utf-8")
 
     def _request() -> List[str]:

--- a/tests/test_vector_store_disabled.py
+++ b/tests/test_vector_store_disabled.py
@@ -1,0 +1,11 @@
+import importlib
+import pytest
+
+@pytest.mark.asyncio
+async def test_vector_store_noop_when_url_missing(monkeypatch):
+    monkeypatch.delenv("VECTOR_STORE_URL", raising=False)
+    from api import vector_store as vs
+    importlib.reload(vs)
+
+    await vs.upsert("hello", [0.1, 0.2])  # should not raise
+    assert await vs.query([0.1, 0.2]) == []


### PR DESCRIPTION
## Summary
- Avoid external vector store calls when `VECTOR_STORE_URL` isn't configured
- Cover missing vector store behavior with a dedicated test

## Testing
- `ruff check api/vector_store.py tests/test_vector_store_disabled.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b37dd6870c83299cade4224c9c584d