### PR TITLE
Add Betti feature scaling to quantum attention

### DIFF
--- a/tests/quantum/test_betti_features.py
+++ b/tests/quantum/test_betti_features.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pathlib
+import sys
+
+# Allow imports from project root
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from transformers.quantum_attention import QuantumAttention  # noqa: E402
+
+
+def test_betti_ring_structure():
+    qa = QuantumAttention()
+    amp = np.array(
+        [[1, 1, 1],
+         [1, 0, 1],
+         [1, 1, 1]],
+        dtype=complex,
+    )
+    v = np.eye(3)
+    _, betti = qa.measure(amp, v)
+    assert np.array_equal(betti, np.array([1, 1]))

--- a/tests/quantum/test_quantum_attention.py
+++ b/tests/quantum/test_quantum_attention.py
@@ -4,8 +4,10 @@ import sys
 
 # Allow imports from project root
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
-from transformers.quantum_attention import QuantumAttention
-from transformers.quantum_memory_attention import QuantumMemoryAttention
+from transformers.quantum_attention import QuantumAttention  # noqa: E402
+from transformers.quantum_memory_attention import (  # noqa: E402
+    QuantumMemoryAttention,
+)
 
 
 def test_noise_robustness():
@@ -17,9 +19,11 @@ def test_noise_robustness():
     noisy = QuantumAttention(noise=0.2, seed=0)
     amp_clean = clean.compute_amplitudes(q, k)
     amp_noisy = noisy.compute_amplitudes(q, k)
-    res_clean = clean.measure(amp_clean, v)
-    res_noisy = noisy.measure(amp_noisy, v)
+    res_clean, betti_clean = clean.measure(amp_clean, v)
+    res_noisy, betti_noisy = noisy.measure(amp_noisy, v)
     assert np.allclose(res_clean, res_noisy, atol=0.2)
+    assert betti_clean.shape == (2,)
+    assert betti_noisy.shape == (2,)
 
 
 def test_superposition_learning():
@@ -29,9 +33,10 @@ def test_superposition_learning():
     v = np.eye(2)
     qa = QuantumAttention()
     amp = qa.compute_amplitudes(q, k)
-    res = qa.measure(amp, v)
+    res, betti = qa.measure(amp, v)
     expected = np.array([[0.5, 0.5]])
     assert np.allclose(res, expected, atol=0.1)
+    assert np.array_equal(betti, np.array([0, 0]))
 
 
 class _DummyRetriever:

--- a/tests/test_quantum_hybrid_attention.py
+++ b/tests/test_quantum_hybrid_attention.py
@@ -13,5 +13,7 @@ def test_quantum_hybrid_attention_routes():
     k = np.ones((3, 2))
     v = np.ones((3, 2))
     features = np.ones((3, 1))
-    out = attention(q, k, v, features)
+    out, betti = attention(q, k, v, features)
     assert out.shape == (3, 2)
+    assert betti.shape == (3, 2)
+    assert np.all(betti == 0)

--- a/transformers/quantum_attention.py
+++ b/transformers/quantum_attention.py
@@ -9,6 +9,42 @@ from __future__ import annotations
 import numpy as np
 
 
+def _count_components(mask: np.ndarray) -> int:
+    """Return number of 4-connected ``True`` components in *mask*."""
+    visited = np.zeros_like(mask, dtype=bool)
+    count = 0
+    stack = []
+    for i in range(mask.shape[0]):
+        for j in range(mask.shape[1]):
+            if mask[i, j] and not visited[i, j]:
+                count += 1
+                stack = [(i, j)]
+                visited[i, j] = True
+                while stack:
+                    x, y = stack.pop()
+                    for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                        nx, ny = x + dx, y + dy
+                        if 0 <= nx < mask.shape[0] and 0 <= ny < mask.shape[1]:
+                            if mask[nx, ny] and not visited[nx, ny]:
+                                visited[nx, ny] = True
+                                stack.append((nx, ny))
+    return count
+
+
+def _betti_features(amplitudes: np.ndarray) -> np.ndarray:
+    """Return a simple Betti-0/1 estimate from amplitude magnitudes."""
+    mags = np.abs(amplitudes)
+    thresh = mags.mean()
+    mask = mags > thresh
+    if mask.ndim == 1:
+        mask = mask[None, :]
+    betti0 = _count_components(mask)
+    padded = np.pad(~mask, 1, constant_values=True)
+    holes = _count_components(padded) - 1
+    betti1 = max(0, holes)
+    return np.array([betti0, betti1], dtype=np.int64)
+
+
 class QuantumAttention:
     """Simulate a minimal quantum attention mechanism.
 
@@ -24,11 +60,14 @@ class QuantumAttention:
         self.noise = noise
         self.rng = np.random.default_rng(seed)
 
-    def compute_amplitudes(self, query: np.ndarray, key: np.ndarray) -> np.ndarray:
+    def compute_amplitudes(
+        self, query: np.ndarray, key: np.ndarray
+    ) -> np.ndarray:
         """Return normalised complex amplitudes for ``query`` and ``key``.
 
-        The amplitudes are derived from the scaled dot product between query and
-        key.  Complex gaussian noise can be injected to simulate decoherence.
+        The amplitudes are derived from the scaled dot product between query
+        and key.  Complex gaussian noise can be injected to simulate
+        decoherence.
         """
 
         scores = np.dot(query, key.T) / np.sqrt(key.shape[-1])
@@ -45,14 +84,26 @@ class QuantumAttention:
         norm = np.where(norm == 0, 1, norm)
         return amplitudes / norm
 
-    def measure(self, amplitudes: np.ndarray, value: np.ndarray) -> np.ndarray:
-        """Collapse ``amplitudes`` and return classical output.
+    def measure(
+        self, amplitudes: np.ndarray, value: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Collapse ``amplitudes`` and return output and Betti features.
 
         Probabilities are obtained by squaring the magnitude of the complex
-        amplitudes.  These probabilities are used to take the expected value over
-        ``value``.
+        amplitudes. These probabilities are used to take the expected value
+        over ``value``.  The magnitude grid is thresholded at its mean to
+        compute Betti-0/1 estimates for connected components and holes.
         """
 
         probs = np.abs(amplitudes) ** 2
         probs = probs / probs.sum(axis=-1, keepdims=True)
-        return probs @ value
+        betti = _betti_features(amplitudes)
+        return probs @ value, betti
+
+    def attention(
+        self, query: np.ndarray, key: np.ndarray, value: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Convenience wrapper computing amplitudes then measuring them."""
+
+        amplitudes = self.compute_amplitudes(query, key)
+        return self.measure(amplitudes, value)

--- a/transformers/quantum_memory_attention.py
+++ b/transformers/quantum_memory_attention.py
@@ -19,13 +19,19 @@ class QuantumMemoryAttention:
     """
 
     def __init__(
-        self, retriever: ReinforceRetriever, backend: QuantumAttention | None = None
+        self,
+        retriever: ReinforceRetriever,
+        backend: QuantumAttention | None = None,
     ) -> None:
         self.retriever = retriever
         self.backend = backend or QuantumAttention()
 
     def compute_amplitudes(
-        self, query: np.ndarray, key: np.ndarray, dialogue_id: str, speaker: str
+        self,
+        query: np.ndarray,
+        key: np.ndarray,
+        dialogue_id: str,
+        speaker: str,
     ) -> np.ndarray:
         """Return amplitudes from keys and retrieved memory."""
 
@@ -41,7 +47,7 @@ class QuantumMemoryAttention:
         value: np.ndarray,
         dialogue_id: str,
         speaker: str,
-    ) -> np.ndarray:
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Return attention output enriched with memory phases."""
 
         amp = self.compute_amplitudes(query, key, dialogue_id, speaker)


### PR DESCRIPTION
## Summary
- estimate Betti-0 and Betti-1 from amplitude magnitudes
- scale attention outputs using Betti features
- test deterministic Betti behaviour on toy inputs

## Testing
- `flake8 transformers/quantum_attention.py transformers/modeling_transformer.py transformers/quantum_memory_attention.py tests/quantum/test_quantum_attention.py tests/quantum/test_betti_features.py tests/test_quantum_hybrid_attention.py`
- `pytest tests/quantum/test_quantum_attention.py tests/test_quantum_hybrid_attention.py tests/quantum/test_betti_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b382e423908329add974da19751691