### PR TITLE
Add dream mode and memory tagging

### DIFF
--- a/dream_mode.py
+++ b/dream_mode.py
@@ -1,0 +1,41 @@
+"""Background dreaming mode generating synthetic dialogues."""
+
+import random
+from typing import List
+
+import pro_memory
+from trainer import Trainer
+
+_PROMPTS = [
+    "hello there",
+    "how are you",
+    "tell me a story",
+    "what is your favorite color",
+    "do you like music",
+]
+
+_RESPONSES = [
+    "I am just code, but I am functioning well",
+    "once upon a time a small bot dreamed",
+    "I like all colors equally",
+    "music is delightful even for code",
+    "thanks for asking",
+]
+
+
+def _simulate_dialogue(turns: int = 3) -> List[str]:
+    """Generate a simple alternating dialogue."""
+    dialogue: List[str] = []
+    for _ in range(turns):
+        dialogue.append(random.choice(_PROMPTS))
+        dialogue.append(random.choice(_RESPONSES))
+    return dialogue
+
+
+async def run(engine: "ProEngine", turns: int = 3) -> None:
+    """Generate dialogue and route through the training loop."""
+    dialogue = _simulate_dialogue(turns)
+    trainer = Trainer()
+    trainer.evolve("dream", dialogue, metric=1.0)
+    for line in dialogue:
+        await pro_memory.add_message(line, tag="dream")

--- a/pro_memory_pool.py
+++ b/pro_memory_pool.py
@@ -24,11 +24,11 @@ async def init_pool(db_path: str, size: int = 1) -> None:
         conn = _POOL[0]
         conn.execute(
             "CREATE TABLE IF NOT EXISTS messages("  # noqa: E501
-            "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT, embedding BLOB)"
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT, embedding BLOB, tag TEXT)"
         )
         conn.execute(
             "CREATE TABLE IF NOT EXISTS responses("  # noqa: E501
-            "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)"
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT, tag TEXT)"
         )
         conn.execute(
             "CREATE TABLE IF NOT EXISTS concepts("  # noqa: E501
@@ -44,11 +44,16 @@ async def init_pool(db_path: str, size: int = 1) -> None:
             "CREATE TABLE IF NOT EXISTS adapter_usage("  # noqa: E501
             "adapter TEXT PRIMARY KEY, count INTEGER)"
         )
-        # Ensure embedding column exists for pre-existing databases
-        try:
-            conn.execute("ALTER TABLE messages ADD COLUMN embedding BLOB")
-        except sqlite3.OperationalError:
-            pass
+        # Ensure new columns exist for pre-existing databases
+        for stmt in [
+            "ALTER TABLE messages ADD COLUMN embedding BLOB",
+            "ALTER TABLE messages ADD COLUMN tag TEXT",
+            "ALTER TABLE responses ADD COLUMN tag TEXT",
+        ]:
+            try:
+                conn.execute(stmt)
+            except sqlite3.OperationalError:
+                pass
         conn.commit()
 
 


### PR DESCRIPTION
## Summary
- Introduce `dream_mode` for generating synthetic dialogues and running them through the training loop
- Schedule background dreaming when system idle, and cancel on shutdown
- Tag stored memories and responses with optional labels for later analysis

## Testing
- `PYTHONPATH=. pytest tests/test_adapter_usage.py::test_adapter_usage -q`
- `pytest` *(interrupted after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68b384bda02c8329ad054cf5ed169b06