### PR TITLE
Refactor memory graph to use differentiable embeddings

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -19,8 +19,10 @@ from transformers.modeling_transformer import MemoryAttention
 class ChatAPI:
     """Minimal interface for interacting with the memory graph."""
 
-    def __init__(self, path: str = "memory_graph.json", dim: int = 32) -> None:
-        self.store = MemoryGraphStore(path)
+    def __init__(self, path: Optional[str] = None, dim: int = 32) -> None:
+        # ``path`` is accepted for backwards compatibility but the new
+        # ``MemoryGraphStore`` keeps all data in-memory.
+        self.store = MemoryGraphStore(dim=dim)
         self.retriever = GraphRetriever(self.store)
         self.attention = MemoryAttention(self.retriever, dim=dim)
 

--- a/pro_memory.py
+++ b/pro_memory.py
@@ -38,6 +38,20 @@ async def persist_embedding(
         await asyncio.to_thread(conn.commit)
 
 
+async def persist_learned_vector(index: int, embedding: np.ndarray) -> None:
+    """Persist an updated embedding for an existing message."""
+
+    async with get_connection() as conn:
+        await asyncio.to_thread(
+            conn.execute,
+            "UPDATE messages SET embedding = ? WHERE rowid = ?",
+            (embedding.tobytes(), index + 1),
+        )
+        await asyncio.to_thread(conn.commit)
+    if _VECTORS is not None and index < _VECTORS.shape[0]:
+        _VECTORS[index] = embedding
+
+
 def _add_to_index(content: str, embedding: np.ndarray) -> None:
     """Add a vector to the in-memory search index."""
     global _VECTORS

--- a/tests/test_memory_vectors.py
+++ b/tests/test_memory_vectors.py
@@ -4,12 +4,13 @@ import sys
 
 import numpy as np
 import pytest
+from autograd import grad
+from autograd import numpy as anp
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import pro_memory  # noqa: E402
 from memory.memory_graph import MemoryGraphStore  # noqa: E402
-from memory.reinforce_retriever import ReinforceRetriever  # noqa: E402
 import morphology  # noqa: E402
 
 
@@ -23,25 +24,31 @@ async def test_store_and_fetch_similar_embeddings(tmp_path, monkeypatch):
     await pro_memory.add_message("goodbye world")
     results = await pro_memory.fetch_similar_messages("hello there", top_k=1)
     assert results == ["hello world"]
-    # ensure embedding persisted as binary blob
+    # Update the first embedding and ensure it persists
+    new_vec = np.ones_like(pro_memory._VECTORS[0])
+    await pro_memory.persist_learned_vector(0, new_vec)
     conn = sqlite3.connect(str(db_path))
-    cur = conn.execute("SELECT embedding FROM messages")
-    blobs = [np.frombuffer(row[0], dtype=np.float32) for row in cur.fetchall()]
-    assert all(blob.size > 0 for blob in blobs)
+    cur = conn.execute("SELECT embedding FROM messages WHERE rowid = 1")
+    blob = np.frombuffer(cur.fetchone()[0], dtype=np.float32)
+    assert np.allclose(blob, new_vec)
     conn.close()
     await pro_memory.close_db()
 
 
-def test_morph_code_storage_and_retrieval():
+def test_embedding_storage_and_gradient_retrieval():
     store = MemoryGraphStore()
     text = "привет мир"
-    store.add_utterance("dlg", "user", text)
+    emb = store.add_utterance("dlg", "user", text)
     dialogue = store.get_dialogue("dlg")
     assert len(dialogue) == 1
-    node = dialogue[0]
     expected = morphology.encode(text)
-    assert np.allclose(node.morph_codes, expected.tolist())
+    assert np.allclose(emb, expected)
 
-    retriever = ReinforceRetriever(store)
-    vec = retriever.retrieve("dlg", "user")
-    assert np.allclose(vec, expected)
+    def loss_fn(q, mat):
+        return store.retrieve(q, "dlg", "user", embeddings=mat) @ anp.ones(store.dim)
+
+    query = anp.random.randn(store.dim)
+    grad_q = grad(lambda q: loss_fn(q, store.embeddings))(query)
+    grad_m = grad(lambda m: loss_fn(query, m))(store.embeddings)
+    assert grad_q.shape == query.shape
+    assert grad_m.shape == store.embeddings.shape


### PR DESCRIPTION
## Summary
- replace JSON-based memory graph with differentiable in-memory embedding matrix
- allow ChatAPI to operate on in-memory memory graph
- expose API for persisting learned memory vectors
- add regression tests for gradient flow and persistence

## Testing
- `ruff check api/chat.py memory/memory_graph.py pro_memory.py tests/test_memory_vectors.py`
- `pytest tests/test_memory_vectors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b38d480564832997850518899b7ccc