### PR TITLE
Introduce fractal resonance adapters

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,41 @@
+"""Training entry point for toy transformer models."""
+
+from __future__ import annotations
+
+import argparse
+import numpy as np
+
+from models.transformer import Transformer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a tiny transformer")
+    parser.add_argument("--dim", type=int, default=16, help="Hidden dimension")
+    parser.add_argument(
+        "--use-fractal-adapter",
+        action="store_true",
+        help="Enable fractal resonance adapter",
+    )
+    parser.add_argument(
+        "--fractal-depth",
+        type=int,
+        default=1,
+        help="Depth of the fractal adapter",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    model = Transformer(
+        args.dim,
+        use_fractal_adapter=args.use_fractal_adapter,
+        fractal_depth=args.fractal_depth,
+    )
+    dummy = np.zeros(args.dim, dtype=np.float32)
+    out = model(dummy)
+    print("output", out)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapter implementations for experimental transformer modules."""
+
+from .fractal_adapter import FractalAdapter
+
+__all__ = ["FractalAdapter"]

--- a/src/adapters/fractal_adapter.py
+++ b/src/adapters/fractal_adapter.py
@@ -1,0 +1,40 @@
+"""Fractal resonance adapter with recursive block construction."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class FractalAdapter:
+    """Generate a recursive sinusoidal pattern.
+
+    The adapter builds a fractal-like vector by recursively splitting the
+    dimension and applying scaled sine waves at each depth.  The result can be
+    added to hidden states to inject a deterministic but rich signal.
+    """
+
+    def __init__(
+        self,
+        depth: int,
+        frequency: float = 1.0,
+        amplitude: float = 0.1,
+    ) -> None:
+        self.depth = max(depth, 0)
+        self.frequency = frequency
+        self.amplitude = amplitude
+
+    def _block(
+        self, dim: int, depth: int, freq: float, amp: float
+    ) -> np.ndarray:
+        base = amp * np.sin(freq * np.arange(dim, dtype=np.float32))
+        if depth == 0 or dim <= 1:
+            return base
+        half = dim // 2
+        left = self._block(half, depth - 1, freq * 2.0, amp / 2.0)
+        right = self._block(dim - half, depth - 1, freq * 2.0, amp / 2.0)
+        return base + np.concatenate([left, right])
+
+    def __call__(self, dim: int) -> np.ndarray:
+        """Return an adapter vector of length ``dim``."""
+
+        return self._block(dim, self.depth, self.frequency, self.amplitude)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model wrappers using experimental adapters."""
+
+from .transformer import Transformer
+
+__all__ = ["Transformer"]

--- a/src/models/transformer.py
+++ b/src/models/transformer.py
@@ -1,0 +1,34 @@
+"""Tiny transformer-like module with optional fractal adapter."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from adapters.fractal_adapter import FractalAdapter
+
+
+class Transformer:
+    """A minimal transformer block supporting fractal adapters."""
+
+    def __init__(
+        self,
+        dim: int,
+        use_fractal_adapter: bool = False,
+        fractal_depth: int = 1,
+    ) -> None:
+        self.dim = dim
+        self.use_fractal_adapter = use_fractal_adapter
+        self.fractal_depth = fractal_depth
+        self.adapter = None
+        if use_fractal_adapter:
+            self.adapter = FractalAdapter(fractal_depth)
+
+    def forward(self, hidden_states: np.ndarray) -> np.ndarray:
+        """Return hidden states enriched with adapter signal when enabled."""
+
+        if self.adapter is None:
+            return hidden_states
+        adapter_vec = self.adapter(hidden_states.shape[-1])
+        return hidden_states + adapter_vec
+
+    __call__ = forward


### PR DESCRIPTION
## Summary
- add recursive fractal resonance adapter implementation
- integrate optional fractal adapter into transformer module via configuration
- extend training script to parse fractal adapter depth from CLI

## Testing
- `python -m flake8 src scripts`
- `pytest` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b38f7a258883298d03b06de63ca535