### PR TITLE
Add meta-optimizer with training hooks and logs

### DIFF
--- a/self_reflect/__init__.py
+++ b/self_reflect/__init__.py
@@ -1,5 +1,5 @@
 """Utilities for the self-reflection training cycle."""
 
-from .trainer import WeaknessDetector, DataGenerator, SelfFineTuner
+from .trainer import MetaOptimizer, SelfFineTuner, WeaknessDetector
 
-__all__ = ["WeaknessDetector", "DataGenerator", "SelfFineTuner"]
+__all__ = ["WeaknessDetector", "MetaOptimizer", "SelfFineTuner"]

--- a/self_reflect/trainer.py
+++ b/self_reflect/trainer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 class WeaknessDetector:
@@ -21,32 +21,42 @@ class WeaknessDetector:
         return weaknesses
 
 
-class DataGenerator:
-    """Generate synthetic training data addressing weaknesses."""
+class MetaOptimizer:
+    """Suggest parameter updates based on detected weaknesses."""
 
-    def generate(self, weaknesses: List[str]) -> List[str]:
-        """Create simple prompts that encourage better behaviour."""
-        data: List[str] = []
-        for weakness in weaknesses:
-            data.append(f"Example conversation improving: {weakness}")
-        return data
+    def optimize(
+        self, weaknesses: List[str], params: Dict[str, float]
+    ) -> Dict[str, float]:
+        """Return a mapping of parameter names to update deltas.
+
+        The strategy is intentionally simple: if any weaknesses are
+        detected, each parameter receives an additive boost proportional to
+        the number of weaknesses. A production implementation could employ
+        gradient-based optimisation or reinforcement learning.
+        """
+        deltas: Dict[str, float] = {}
+        if not weaknesses:
+            return deltas
+        strength = 0.1 * len(weaknesses)
+        for name in params:
+            deltas[name] = strength
+        return deltas
 
 
 class SelfFineTuner:
-    """Orchestrate self-reflection and fine-tuning cycle."""
+    """Orchestrate self-reflection and meta-optimisation cycle."""
 
     def __init__(self, model: Optional[object] = None) -> None:
         self.model = model
 
-    def run(self, conversations: List[str]) -> List[str]:
-        """Perform one cycle of detection, data generation and fine-tuning.
+    def run(self, conversations: List[str], params: Dict[str, float]) -> Dict[str, float]:
+        """Detect weaknesses and propose parameter updates.
 
-        Returns the list of weaknesses that were targeted.
+        Returns a dictionary of parameter deltas suggested by the
+        :class:`MetaOptimizer`.
         """
         detector = WeaknessDetector()
         weaknesses = detector.detect(conversations)
-        generator = DataGenerator()
-        training_data = generator.generate(weaknesses)
-        # Placeholder: integrate with actual fine-tuning pipeline.
-        _ = training_data
-        return weaknesses
+        optimizer = MetaOptimizer()
+        deltas = optimizer.optimize(weaknesses, params)
+        return deltas

--- a/tests/test_meta_optimizer.py
+++ b/tests/test_meta_optimizer.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import shutil
+
+from trainer import Trainer
+
+
+def test_meta_optimizer_updates_params():
+    log_dir = Path("logs/meta")
+    if log_dir.exists():
+        shutil.rmtree(log_dir)
+    trainer = Trainer(eval_interval=1)
+    trainer.params = {"w": 1.0}
+    conversations = ["??"]
+    trainer.train_step("w", 1.0, conversations=conversations)
+    assert trainer.params["w"] > 1.0
+    before_file = log_dir / "epoch_1_before.json"
+    after_file = log_dir / "epoch_1_after.json"
+    assert before_file.exists()
+    assert after_file.exists()


### PR DESCRIPTION
## Summary
- introduce `MetaOptimizer` that proposes parameter deltas from conversation weaknesses
- hook training loop to invoke self-reflection after each epoch and log pre/post parameters
- add regression test verifying parameters change and audit logs are produced

## Testing
- `ruff check self_reflect/trainer.py trainer.py self_reflect/__init__.py tests/test_meta_optimizer.py`
- `PYTHONPATH=. pytest tests/test_meta_optimizer.py tests/test_resonance.py`


------
https://chatgpt.com/codex/tasks/task_e_68b391bc8cc4832994051dd470c88bcd