### PR TITLE
Add hyper block and block factory

### DIFF
--- a/tests/test_block_factory.py
+++ b/tests/test_block_factory.py
@@ -1,0 +1,15 @@
+import numpy as np
+from transformers.modeling_transformer import block_factory
+
+
+def test_block_factory_generates_distinct_outputs():
+    x = np.array([1.0, 1.0], dtype=np.float32)
+    context = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+
+    static_block = block_factory(2, 2, use_hyper=False)
+    hyper_block = block_factory(2, 2, use_hyper=True)
+
+    static_out = static_block(x, context)
+    hyper_out = hyper_block(x, context)
+
+    assert not np.allclose(static_out, hyper_out)

--- a/transformers/blocks/__init__.py
+++ b/transformers/blocks/__init__.py
@@ -11,6 +11,7 @@ from .reasoning import (
     SymbolicNot,
     SymbolicReasoner,
 )
+from .hyper_block import HyperBlock
 
 __all__ = [
     "DynamicContextGate",
@@ -22,4 +23,5 @@ __all__ = [
     "SymbolicOr",
     "SymbolicNot",
     "SymbolicReasoner",
+    "HyperBlock",
 ]

--- a/transformers/blocks/hyper_block.py
+++ b/transformers/blocks/hyper_block.py
@@ -1,0 +1,25 @@
+import numpy as np
+import numpy.typing as npt
+
+
+class HyperBlock:
+    """Generate a weight matrix from a context vector."""
+
+    def __init__(self, in_dim: int, out_dim: int) -> None:
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+
+    def weights(
+        self, context: npt.NDArray[np.float32]
+    ) -> npt.NDArray[np.float32]:
+        flat = np.resize(
+            context.astype(np.float32), self.out_dim * self.in_dim
+        )
+        return flat.reshape(self.out_dim, self.in_dim)
+
+    def __call__(
+        self, x: npt.NDArray[np.float32], context: npt.NDArray[np.float32]
+    ) -> npt.NDArray[np.float32]:
+        """Apply generated weights to *x* using *context*."""
+        w = self.weights(context)
+        return w @ x

--- a/transformers/modeling_transformer.py
+++ b/transformers/modeling_transformer.py
@@ -18,6 +18,7 @@ import ast
 
 import numpy as np
 import morphology
+from .blocks.hyper_block import HyperBlock
 
 from memory.memory_graph import GraphRetriever
 from memory.reinforce_retriever import ReinforceRetriever
@@ -230,3 +231,25 @@ class QuantumMemoryLayer:
         return self.attention.attention(
             query, key, value, dialogue_id, speaker
         )
+
+
+class StaticBlock:
+    """Linear block with fixed weights."""
+
+    def __init__(self, weights: np.ndarray) -> None:
+        self.weights = weights
+
+    def __call__(
+        self, x: np.ndarray, context: np.ndarray | None = None
+    ) -> np.ndarray:
+        return self.weights @ x
+
+
+def block_factory(
+    in_dim: int, out_dim: int, use_hyper: bool = False
+) -> StaticBlock | HyperBlock:
+    """Return a static or hyper block based on *use_hyper* flag."""
+    if use_hyper:
+        return HyperBlock(in_dim, out_dim)
+    weights = np.eye(out_dim, in_dim, dtype=np.float32)
+    return StaticBlock(weights)


### PR DESCRIPTION
## Summary
- add HyperBlock for context-conditioned weight generation
- introduce block_factory to switch between static and hyper blocks
- test factory returns differing outputs for static and hyper modes

## Testing
- `python -m flake8 transformers/blocks/hyper_block.py transformers/blocks/__init__.py transformers/modeling_transformer.py tests/test_block_factory.py`
- `PYTHONPATH=. pytest tests/test_block_factory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3923238848329848b3ce5c766d32b