### PR TITLE
Add harmonic resonance layer with shared weights

### DIFF
--- a/tests/attention/test_dynamic_context_gate.py
+++ b/tests/attention/test_dynamic_context_gate.py
@@ -5,10 +5,7 @@ import sys
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 from pro_predict import MiniSelfAttention  # noqa: E402
 from transformers.blocks import ResonantDropout  # noqa: E402
-from transformers.modeling_transformer import (  # noqa: E402
-    MemoryAttention,
-    ResonantAdapter,
-)
+from transformers.modeling_transformer import MemoryAttention  # noqa: E402
 
 
 def test_gate_can_zero_context():
@@ -26,7 +23,7 @@ def test_gate_can_zero_context():
     assert any(abs(boosted[w]) > abs(baseline[w]) for w in vocab)
 
 
-def test_resonant_adapter_adds_signal():
+def test_harmonic_layer_adds_signal():
     class EmptyRetriever:
         def last_message(self, dialogue_id, speaker):
             return None
@@ -34,8 +31,8 @@ def test_resonant_adapter_adds_signal():
     attention = MemoryAttention(EmptyRetriever(), dim=4)
     hidden = np.zeros(4, dtype=np.float32)
     out = attention(hidden, "d", "s")
-    expected = ResonantAdapter(1.0, 0.1)(4)
-    assert np.allclose(out, expected)
+    expected = attention.resonance(hidden)
+    assert np.allclose(out, hidden + expected)
 
 
 def test_resonant_dropout_depends_on_frequency():

--- a/tests/test_harmonic_resonance_layer.py
+++ b/tests/test_harmonic_resonance_layer.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from transformers.modeling_transformer import MemoryAttention
+from transformers.resonant_layers import HarmonicResonanceLayer
+
+
+def test_shared_weights_across_layers() -> None:
+    freqs = [0.1, 0.2]
+    layer1 = HarmonicResonanceLayer(4, freqs)
+    layer2 = HarmonicResonanceLayer(4, freqs)
+    assert layer1.weights is layer2.weights
+    layer1.modulate(np.ones(4, dtype=np.float32))
+    assert np.allclose(layer1.weights, layer2.weights)
+
+
+def test_memory_attention_forward_pass() -> None:
+    class DummyRetriever:
+        def last_message(self, dialogue_id, speaker):
+            return None
+
+    attn = MemoryAttention(DummyRetriever(), dim=4, frequencies=[0.1, 0.2])
+    hidden = np.zeros(4, dtype=np.float32)
+    out = attn(hidden, "d", "s")
+    assert out.shape == hidden.shape
+    assert not np.allclose(out, 0.0)

--- a/tests/test_memory_kernel.py
+++ b/tests/test_memory_kernel.py
@@ -1,10 +1,6 @@
 import numpy as np
 
-from transformers.modeling_transformer import (
-    MemoryAttention,
-    ResonantAdapter,
-    register_kernel,
-)
+from transformers.modeling_transformer import MemoryAttention, register_kernel
 
 
 class DummyRetriever:
@@ -22,7 +18,7 @@ def test_custom_memory_kernel_executes_and_resets():
     register_kernel("lambda h, m: h * 0.5 + m")
     attn = MemoryAttention(retriever, dim=dim)
     out = attn(hidden, "d", "s")
-    adapter = ResonantAdapter(1.0, 0.1)(dim)
-    assert np.allclose(out, hidden * 0.5 + np.ones(dim) + adapter)
+    harmonic = attn.resonance(hidden)
+    assert np.allclose(out, hidden * 0.5 + np.ones(dim) + harmonic)
     # Clean up so subsequent tests use default behaviour
     register_kernel(None)

--- a/transformers/resonant_layers.py
+++ b/transformers/resonant_layers.py
@@ -1,0 +1,48 @@
+"""Simple harmonic layers for transformer experiments."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class HarmonicResonanceLayer:
+    """Apply a sinusoidal basis with shared weights.
+
+    Parameters
+    ----------
+    dim: int
+        Dimensionality of the hidden states.
+    frequencies: Sequence[float]
+        Frequencies used to construct the Fourier basis.  All instances of
+        :class:`HarmonicResonanceLayer` share the same weights which are
+        initialised on first construction.
+    """
+
+    _shared_weights: np.ndarray | None = None
+
+    def __init__(self, dim: int, frequencies: np.ndarray) -> None:
+        self.dim = dim
+        self.frequencies = np.asarray(frequencies, dtype=np.float32)
+        if (
+            HarmonicResonanceLayer._shared_weights is None
+            or HarmonicResonanceLayer._shared_weights.shape[0] != len(self.frequencies)
+        ):
+            HarmonicResonanceLayer._shared_weights = np.ones(
+                len(self.frequencies), dtype=np.float32
+            )
+
+    @property
+    def weights(self) -> np.ndarray:
+        assert HarmonicResonanceLayer._shared_weights is not None
+        return HarmonicResonanceLayer._shared_weights
+
+    def modulate(self, memory: np.ndarray) -> None:
+        """Blend *memory* into the shared weights."""
+        w = self.weights
+        HarmonicResonanceLayer._shared_weights = w + memory[: w.shape[0]]
+
+    def __call__(self, hidden_states: np.ndarray) -> np.ndarray:
+        """Compute the harmonic component for ``hidden_states``."""
+        idx = np.arange(self.dim, dtype=np.float32)
+        basis = np.sin(np.outer(idx, self.frequencies))
+        return basis @ self.weights


### PR DESCRIPTION
## Summary
- introduce `HarmonicResonanceLayer` applying Fourier basis with shared weights
- integrate harmonic layer into `MemoryAttention` with frequency parameter and memory-driven modulation
- update tests and add coverage for weight sharing and forward pass

## Testing
- `python -m py_compile transformers/resonant_layers.py transformers/modeling_transformer.py tests/test_harmonic_resonance_layer.py tests/test_memory_kernel.py tests/attention/test_dynamic_context_gate.py`
- `PYTHONPATH=. pytest tests/test_harmonic_resonance_layer.py tests/test_memory_kernel.py tests/attention/test_dynamic_context_gate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3935735dc83299988b7111ad38669