### PR TITLE
Add complex-valued quantum-phase attention

### DIFF
--- a/src/attention/__init__.py
+++ b/src/attention/__init__.py
@@ -1,0 +1,8 @@
+"""Attention modules.
+
+This package currently exposes :class:`ComplexAttention` for toy tests.
+"""
+
+from .complex_attention import ComplexAttention
+
+__all__ = ["ComplexAttention"]

--- a/src/attention/complex_attention.py
+++ b/src/attention/complex_attention.py
@@ -1,0 +1,56 @@
+"""Complex-valued self-attention using ``torch.view_as_complex``.
+
+This is a tiny demonstrative implementation that interprets real and
+imaginary parts stacked along the last dimension.  Inputs are expected to
+have shape ``(..., 2 * dim)`` where the final dimension alternates real and
+imaginary components.  The module converts them into complex tensors,
+performs a scaled dot-product attention in the complex domain and returns the
+result flattened back to real/imag parts.
+"""
+
+from __future__ import annotations
+
+import math
+import torch
+from torch import nn
+
+
+def _to_complex(x: torch.Tensor) -> torch.Tensor:
+    """View the last dimension of ``x`` as complex numbers."""
+    # ``torch.view_as_complex`` expects an extra dimension of size 2 holding
+    # the real and imaginary parts respectively.
+    x = x.view(*x.shape[:-1], -1, 2)
+    return torch.view_as_complex(x)
+
+
+class ComplexAttention(nn.Module):
+    """Minimal complex self-attention layer."""
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.dim = dim
+        # projections produce real and imaginary parts for Q, K, V
+        self.q_proj = nn.Linear(dim, 2 * dim)
+        self.k_proj = nn.Linear(dim, 2 * dim)
+        self.v_proj = nn.Linear(dim, 2 * dim)
+        self.out_proj = nn.Linear(2 * dim, dim)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Return attention output for ``hidden_states``.
+
+        ``hidden_states`` is interpreted as real-valued input.  It is projected
+        to complex queries, keys and values.  Attention weights are computed
+        from the real part of the complex scores.  The complex result is
+        flattened back to real/imag parts before a final linear projection.
+        """
+
+        q = _to_complex(self.q_proj(hidden_states))
+        k = _to_complex(self.k_proj(hidden_states))
+        v = _to_complex(self.v_proj(hidden_states))
+
+        scale = 1.0 / math.sqrt(self.dim)
+        scores = torch.matmul(q, k.conj().transpose(-2, -1)) * scale
+        weights = torch.softmax(scores.real, dim=-1)
+        out = torch.matmul(weights, v)
+        out = torch.view_as_real(out).reshape(*hidden_states.shape[:-1], -1)
+        return self.out_proj(out)

--- a/src/models/transformer_block.py
+++ b/src/models/transformer_block.py
@@ -1,0 +1,67 @@
+"""Simplified transformer block that can use complex attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from torch import nn
+except ModuleNotFoundError:  # pragma: no cover - handled in tests
+    torch = None
+    nn = object  # type: ignore[misc,assignment]
+
+try:  # pragma: no cover - optional dependency
+    from attention.complex_attention import ComplexAttention
+except Exception:  # pragma: no cover - module requires torch
+    ComplexAttention = None
+
+
+@dataclass
+class TransformerBlockConfig:
+    """Configuration for :class:`TransformerBlock`.
+
+    Parameters
+    ----------
+    dim: int
+        Dimensionality of the input embeddings.
+    use_complex_attention: bool, optional
+        Whether to enable :class:`ComplexAttention` inside the block.
+    """
+
+    dim: int
+    use_complex_attention: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of this config."""
+        return {"dim": self.dim, "use_complex_attention": self.use_complex_attention}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TransformerBlockConfig":
+        """Instantiate config from ``data``.
+
+        Missing ``use_complex_attention`` defaults to ``False`` for backwards
+        compatibility.
+        """
+        return cls(dim=int(data["dim"]), use_complex_attention=bool(data.get("use_complex_attention", False)))
+
+
+class TransformerBlock(nn.Module if torch else object):  # type: ignore[misc]
+    """Very small transformer block wrapper."""
+
+    def __init__(self, config: TransformerBlockConfig) -> None:  # pragma: no cover - simple wiring
+        if torch is None or ComplexAttention is None:
+            raise ModuleNotFoundError("torch is required for TransformerBlock")
+        super().__init__()
+        self.config = config
+        self.attention = (
+            ComplexAttention(config.dim) if config.use_complex_attention else None
+        )
+
+    def forward(self, hidden_states: "torch.Tensor") -> "torch.Tensor":  # pragma: no cover - thin wrapper
+        if self.attention is not None:
+            return self.attention(hidden_states)
+        return hidden_states
+
+    __call__ = forward

--- a/tests/test_complex_attention.py
+++ b/tests/test_complex_attention.py
@@ -1,0 +1,49 @@
+import pathlib
+import sys
+
+import pytest
+
+
+def _add_src_to_path():
+    root = pathlib.Path(__file__).resolve().parents[1]
+    src = root / "src"
+    sys.path.append(str(src))
+
+
+_add_src_to_path()
+
+from models.transformer_block import TransformerBlockConfig  # noqa: E402
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from attention.complex_attention import ComplexAttention  # noqa: E402
+    from models.transformer_block import TransformerBlock  # noqa: E402
+except ModuleNotFoundError:  # pragma: no cover - handled in skip conditions
+    torch = None
+    ComplexAttention = None
+    TransformerBlock = None
+
+
+def test_config_serialisation_roundtrip():
+    cfg = TransformerBlockConfig(dim=4, use_complex_attention=True)
+    data = cfg.to_dict()
+    assert data["use_complex_attention"] is True
+    new_cfg = TransformerBlockConfig.from_dict(data)
+    assert new_cfg == cfg
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_complex_attention_runs():
+    attn = ComplexAttention(4)
+    x = torch.randn(2, 4)
+    out = attn(x)
+    assert out.shape == (2, 4)
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_transformer_block_uses_attention():
+    cfg = TransformerBlockConfig(dim=4, use_complex_attention=True)
+    block = TransformerBlock(cfg)
+    x = torch.randn(2, 4)
+    out = block(x)
+    assert out.shape == x.shape


### PR DESCRIPTION
## Summary
- add complex-valued self-attention built on `torch.view_as_complex`
- allow TransformerBlock to toggle complex attention and serialize configs
- cover complex attention with dedicated tests

## Testing
- `python -m py_compile src/attention/complex_attention.py src/attention/__init__.py src/models/transformer_block.py tests/test_complex_attention.py`
- `pytest tests/test_complex_attention.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3951124e08329a4da15da16c55136