### PR TITLE
Holographic Memory for Token Resonance

### DIFF
--- a/memory/memory_graph.py
+++ b/memory/memory_graph.py
@@ -85,7 +85,8 @@ class GraphRetriever:
         self.store = store
 
     def last_message(self, dialogue_id: str, speaker: str) -> Optional[str]:
-        """Return the most recent message for ``speaker`` in ``dialogue_id``."""
+        """Return the most recent message for ``speaker`` in
+        ``dialogue_id``."""
 
         dialogue = self.store.get_dialogue(dialogue_id)
         for node in reversed(dialogue):
@@ -97,3 +98,10 @@ class GraphRetriever:
         """Return all message texts from ``dialogue_id``."""
 
         return [node.text for node in self.store.get_dialogue(dialogue_id)]
+
+    def recent_messages(self, dialogue_id: str, n: int = 3) -> List[str]:
+        """Return the last ``n`` message texts from ``dialogue_id``."""
+
+        dialogue = self.store.get_dialogue(dialogue_id)
+        recent = dialogue[-n:]
+        return [node.text for node in recent]


### PR DESCRIPTION
## Summary
- add `recent_messages` helper to `GraphRetriever`
- implement `HoloMemoryGate` that builds holographic vectors from recent dialogue turns
- gate transformer memory and quantum attention with holographic context

## Testing
- `python -m flake8 memory/memory_graph.py transformers/blocks/attention.py transformers/modeling_transformer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37e6daf08832982561021119c2800