### PR TITLE
Add fractal link resonance averaging

### DIFF
--- a/self_reflect/trainer.py
+++ b/self_reflect/trainer.py
@@ -59,4 +59,24 @@ class SelfFineTuner:
         weaknesses = detector.detect(conversations)
         optimizer = MetaOptimizer()
         deltas = optimizer.optimize(weaknesses, params)
+
+        # After generating parameter updates, blend the weights of linked
+        # layers so their gradients resonate with each other.  This uses the
+        # ``fractal_links`` configuration defined in :mod:`trainer`.
+        if self.model is not None:
+            try:
+                from trainer import fractal_links  # local import to avoid cycle
+            except Exception:  # pragma: no cover - in case trainer is missing
+                fractal_links = []  # type: ignore[assignment]
+            resonance = getattr(self.model, "resonance", 0.5)
+            for left, right in fractal_links:
+                w_left = getattr(self.model, left, None)
+                w_right = getattr(self.model, right, None)
+                if w_left is None or w_right is None:
+                    continue
+                new_left = (1 - resonance) * w_left + resonance * w_right
+                new_right = (1 - resonance) * w_right + resonance * w_left
+                setattr(self.model, left, new_left)
+                setattr(self.model, right, new_right)
+
         return deltas

--- a/tests/test_pro_tune_cli.py
+++ b/tests/test_pro_tune_cli.py
@@ -16,3 +16,32 @@ def test_pro_tune_cli(tmp_path):
     assert state_path.exists()
     data = json.loads(state_path.read_text())
     assert data["word_counts"].get("hello", 0) == 1
+
+
+def test_fractal_links_converge():
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from trainer import fractal_links
+    from self_reflect.trainer import SelfFineTuner
+
+    # Link two dummy layers and prepare a simple model with distinct weights
+    previous_links = fractal_links.copy()
+    fractal_links.clear()
+    fractal_links.append(("w1", "w2"))
+
+    class Dummy:
+        def __init__(self) -> None:
+            self.w1 = 0.0
+            self.w2 = 10.0
+            self.resonance = 0.5
+
+    model = Dummy()
+    tuner = SelfFineTuner(model)
+    before = abs(model.w1 - model.w2)
+    tuner.run(["??"], {})
+    after = abs(model.w1 - model.w2)
+
+    fractal_links[:] = previous_links
+    assert after < before

--- a/trainer.py
+++ b/trainer.py
@@ -1,7 +1,7 @@
 """Simple training loop with layer evaluation and time folding."""
 import json
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 from autoadapt import LayerMutator, MetricMonitor
@@ -11,6 +11,11 @@ from transformers.time_fold import TimeFoldTransformer
 from pro_forecast import simulate_paths, backpropagate_forecast
 from resonance.p2p_resonance import P2PResonance
 from self_reflect.trainer import SelfFineTuner
+
+# Pairs of layer names whose gradients should mirror each other during
+# self-reflection.  Layers listed here will have their weights blended
+# symmetrically by :class:`~self_reflect.SelfFineTuner` after each cycle.
+fractal_links: List[Tuple[str, str]] = []
 
 
 class Trainer:


### PR DESCRIPTION
## Summary
- introduce `fractal_links` for mapping layers that reflect each other
- blend linked layer weights inside `SelfFineTuner.run` using a resonance coefficient
- add test ensuring linked weights move closer after one tuning cycle

## Testing
- `ruff check trainer.py self_reflect/trainer.py tests/test_pro_tune_cli.py`
- `pytest`
- `pytest tests/test_pro_tune_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b39a5b7af08329b25d5d9d2a4be6b3