### PR TITLE
feat: add complex embeddings and phase-aware attention

### DIFF
--- a/pro_rag_embedding.py
+++ b/pro_rag_embedding.py
@@ -4,7 +4,10 @@ import asyncio
 # Simple deterministic "mini-SIAMESE" style embedding generator.
 # This is intentionally lightweight so tests do not require heavy models.
 _DIM = 32
-_W = np.random.default_rng(0).normal(size=(256, _DIM)).astype(np.float32)
+_RNG = np.random.default_rng(0)
+_W = (
+    _RNG.normal(size=(256, _DIM)) + 1j * _RNG.normal(size=(256, _DIM))
+).astype(np.complex64)
 _LOCK = asyncio.Lock()
 
 
@@ -19,12 +22,12 @@ async def embed_sentence(text: str) -> np.ndarray:
     """Return a normalized embedding for given text."""
     async with _LOCK:
         # embedding = char histogram projected via fixed random matrix
-        vec = _char_vector(text)
+        vec = _char_vector(text).astype(np.complex64)
         emb = vec @ _W
         norm = np.linalg.norm(emb)
         if norm:
             emb = emb / norm
-        return emb.astype(np.float32)
+        return emb.astype(np.complex64)
 
 
 async def extract_entities_relations(text: str):

--- a/tests/test_phase_memory_cycle.py
+++ b/tests/test_phase_memory_cycle.py
@@ -1,0 +1,29 @@
+import numpy as np
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pro_rag_embedding
+from transformers.modeling_transformer import MemoryAttention
+
+
+class _DummyRetriever:
+    def __init__(self, vec: np.ndarray) -> None:
+        self.vec = vec
+
+    def retrieve(self, dialogue_id: str, speaker: str) -> np.ndarray:  # noqa: D401 - simple stub
+        return self.vec
+
+
+@pytest.mark.asyncio
+async def test_phase_preserved_through_cycle():
+    text = "phase memory test"
+    mem_vec = await pro_rag_embedding.embed_sentence(text)
+    retriever = _DummyRetriever(mem_vec)
+    attn = MemoryAttention(retriever, mem_vec.shape[0])
+    hidden = np.zeros_like(mem_vec)
+    out = attn(hidden, "dlg", "user")
+    assert np.allclose(np.angle(out), np.angle(mem_vec))
+


### PR DESCRIPTION
## Summary
- generate complex embeddings using a deterministic complex projection
- combine memory and hidden state vectors using phase-aware operations
- add regression test to ensure phase is preserved through memory cycle

## Testing
- `ruff check pro_rag_embedding.py transformers/modeling_transformer.py tests/test_phase_memory_cycle.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'autograd')*
- `pytest tests/test_phase_memory_cycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68b39abd3a308329b5c6d8346683ec8c