### PR TITLE
Add quantum dropout to MiniSelfAttention

### DIFF
--- a/pro_predict.py
+++ b/pro_predict.py
@@ -12,6 +12,7 @@ import contextlib
 
 import morphology
 from transformers.blocks import DynamicContextGate
+from transformers.quantum_dropout import quantum_dropout
 
 from pro_metrics import tokenize, lowercase
 from pro_memory import DB_PATH
@@ -301,6 +302,7 @@ class MiniSelfAttention:
         att = np.exp(att - att.max(axis=-1, keepdims=True))
         att = att / att.sum(axis=-1, keepdims=True)
         context = att @ v
+        context = quantum_dropout(context)
         if self.gate:
             context = self.gate(context)
         pooled = context.mean(axis=0)
@@ -327,6 +329,7 @@ class MiniSelfAttention:
         att = np.exp(att - att.max(axis=-1, keepdims=True))
         att = att / att.sum(axis=-1, keepdims=True)
         context = att @ v
+        context = quantum_dropout(context)
         if self.gate:
             context = self.gate(context)
         pooled = context.mean(axis=0)

--- a/tests/attention/test_quantum_dropout.py
+++ b/tests/attention/test_quantum_dropout.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pathlib
+import sys
+
+# Allow imports from project root
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from pro_predict import MiniSelfAttention  # noqa: E402
+
+
+def test_logit_stochastic_with_fixed_seed():
+    vocab = ["a", "b"]
+    model = MiniSelfAttention(vocab, dim=4, use_gate=False)
+    tokens = ["a"]
+    np.random.seed(0)
+    out1 = model.logits(tokens)
+    np.random.seed(0)
+    out2 = model.logits(tokens)
+    assert any(out1[w] != out2[w] for w in vocab)

--- a/transformers/quantum_dropout.py
+++ b/transformers/quantum_dropout.py
@@ -1,0 +1,30 @@
+"""Random phase rotation followed by magnitude projection."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def quantum_dropout(x: np.ndarray, rng: np.random.Generator | None = None) -> np.ndarray:
+    """Return ``x`` after random phase rotation and measurement.
+
+    Each element of ``x`` is treated as the magnitude of a complex amplitude.
+    A random phase is sampled, the amplitude is rotated by this phase and the
+    absolute value of its real projection is returned. The procedure mimics a
+    probabilistic ``dropout`` where components can vanish depending on the
+    sampled phase.
+
+    Parameters
+    ----------
+    x:
+        Real input array representing amplitudes.
+    rng:
+        Optional random number generator. If ``None`` a fresh generator is
+        created, leading to non-deterministic behaviour even when global seeds
+        are fixed.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+    phase = rng.uniform(0.0, 2 * np.pi, size=x.shape)
+    rotated = x.astype(np.complex128) * np.exp(1j * phase)
+    return np.abs(rotated.real)


### PR DESCRIPTION
## Summary
- add `quantum_dropout` helper for random phase rotation of activations
- apply `quantum_dropout` inside `MiniSelfAttention.logits`
- test stochastic behaviour of `MiniSelfAttention` logits

## Testing
- `ruff check pro_predict.py transformers/quantum_dropout.py tests/attention/test_quantum_dropout.py`
- `pytest -q tests/attention/test_dynamic_context_gate.py tests/attention/test_quantum_dropout.py`


------
https://chatgpt.com/codex/tasks/task_e_68b39a9b2cec832997ed0ea9b28406a6