### PR TITLE
Add autograd dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 aiosqlite
 watchfiles
 qiskit
+autograd


### PR DESCRIPTION
## Summary
- include autograd in requirements for differentiable memory graph

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'memory.memristor_cell')*
- `flake8` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a058539c8329825b5c6eee9a8dbf