### PR TITLE
Use asyncio threads for RAG embedding projection

### DIFF
--- a/tests/test_embedding_parallel_benchmark.py
+++ b/tests/test_embedding_parallel_benchmark.py
@@ -1,0 +1,18 @@
+import asyncio
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from pro_rag_embedding import embed_sentence
+
+
+@pytest.mark.asyncio
+async def test_parallel_embedding_latency_under_five_seconds():
+    texts = ["benchmark"] * 1000
+    start = time.perf_counter()
+    await asyncio.gather(*(embed_sentence(t) for t in texts))
+    duration = time.perf_counter() - start
+    assert duration < 5, f"parallel embedding took {duration:.2f}s"


### PR DESCRIPTION
## Summary
- replace global async lock with `asyncio.to_thread` to project character vectors
- mark the random projection matrix read-only to ensure thread safety
- add benchmark validating that concurrent embedding calls finish within five seconds

## Testing
- `ruff check pro_rag_embedding.py tests/test_embedding_parallel_benchmark.py`
- `pytest tests/test_embedding_parallel_benchmark.py tests/test_phase_memory_cycle.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3a183698083298c83b97e5e09601a