### PR TITLE
Use aiohttp for Telegram requests

### DIFF
--- a/pro_tg.py
+++ b/pro_tg.py
@@ -1,11 +1,8 @@
-"""Simple asynchronous Telegram bot using urllib for HTTP requests."""
+"""Simple asynchronous Telegram bot using aiohttp for HTTP requests."""
 
 import os
 import asyncio
-import json
-from urllib import request, parse
-
-from pro_engine import ProEngine
+import aiohttp
 
 TOKEN = os.environ.get("TELEGRAM_TOKEN")
 if not TOKEN:
@@ -14,57 +11,52 @@ if not TOKEN:
 API_URL = f"https://api.telegram.org/bot{TOKEN}"
 
 
-engine = ProEngine()
-
-
-def _sync_request(req: request.Request) -> dict:
-    with request.urlopen(req) as resp:  # type: ignore[arg-type]
-        return json.loads(resp.read().decode())
-
-
-async def _request(req: request.Request) -> dict:
-    return await asyncio.to_thread(_sync_request, req)
-
-
-async def get_updates(offset: int | None = None) -> list[dict]:
+async def get_updates(
+    session: aiohttp.ClientSession, offset: int | None = None
+) -> list[dict]:
     params = {"timeout": 30}
     if offset is not None:
         params["offset"] = offset
-    url = f"{API_URL}/getUpdates?{parse.urlencode(params)}"
-    req = request.Request(url)
-    data = await _request(req)
+    url = f"{API_URL}/getUpdates"
+    async with session.get(url, params=params) as resp:
+        data = await resp.json()
     return data.get("result", [])
 
 
-async def send_message(chat_id: int, text: str) -> None:
+async def send_message(
+    session: aiohttp.ClientSession, chat_id: int, text: str
+) -> None:
     url = f"{API_URL}/sendMessage"
-    payload = json.dumps({"chat_id": chat_id, "text": text}).encode()
-    headers = {"Content-Type": "application/json"}
-    req = request.Request(url, data=payload, headers=headers)
-    await _request(req)
+    payload = {"chat_id": chat_id, "text": text}
+    async with session.post(url, json=payload) as resp:
+        await resp.json()
 
 
 async def main() -> None:
+    from pro_engine import ProEngine
+
+    engine = ProEngine()
     await engine.setup()
     offset = None
-    try:
-        while True:
-            try:
-                updates = await get_updates(offset)
-                for update in updates:
-                    offset = update["update_id"] + 1
-                    message = update.get("message") or {}
-                    text = message.get("text")
-                    chat = message.get("chat") or {}
-                    chat_id = chat.get("id")
-                    if chat_id and text:
-                        response, _ = await engine.process_message(text)
-                        await send_message(chat_id, response)
-            except Exception as exc:  # pragma: no cover - logging only
-                print(f"Error: {exc}")
-                await asyncio.sleep(1)
-    finally:
-        await engine.shutdown()
+    async with aiohttp.ClientSession() as session:
+        try:
+            while True:
+                try:
+                    updates = await get_updates(session, offset)
+                    for update in updates:
+                        offset = update["update_id"] + 1
+                        message = update.get("message") or {}
+                        text = message.get("text")
+                        chat = message.get("chat") or {}
+                        chat_id = chat.get("id")
+                        if chat_id and text:
+                            response, _ = await engine.process_message(text)
+                            await send_message(session, chat_id, response)
+                except Exception as exc:  # pragma: no cover - logging only
+                    print(f"Error: {exc}")
+                    await asyncio.sleep(1)
+        finally:
+            await engine.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/test_pro_tg_latency.py
+++ b/tests/test_pro_tg_latency.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import time
+from pathlib import Path
+
+import aiohttp
+from aiohttp import web
+import pytest
+
+# Ensure token for module import
+os.environ.setdefault("TELEGRAM_TOKEN", "TOKEN")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pro_tg  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_telegram_latency_under_5s():
+    app = web.Application()
+
+    async def handle_get_updates(request):
+        return web.json_response({"ok": True, "result": []})
+
+    async def handle_send_message(request):
+        data = await request.json()
+        return web.json_response({"ok": True, "result": data})
+
+    app.router.add_get("/botTOKEN/getUpdates", handle_get_updates)
+    app.router.add_post("/botTOKEN/sendMessage", handle_send_message)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "localhost", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    pro_tg.API_URL = f"http://localhost:{port}/botTOKEN"
+
+    async with aiohttp.ClientSession() as session:
+        start = time.perf_counter()
+        await pro_tg.get_updates(session)
+        await pro_tg.send_message(session, 1, "hi")
+        elapsed = time.perf_counter() - start
+
+    await runner.cleanup()
+
+    assert elapsed < 5


### PR DESCRIPTION
## Summary
- Switch Telegram bot to aiohttp for async HTTP calls
- Share a single aiohttp session across update polling and message sending
- Add latency test with mocked Telegram API to ensure responses under 5s

## Testing
- `ruff check pro_tg.py tests/test_pro_tg_latency.py`
- `pytest tests/test_pro_tg_latency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3a2c9e2488329be908348334d2e6d