### PR TITLE
Add aiohttp dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiosqlite
 watchfiles
 qiskit
 autograd
+aiohttp


### PR DESCRIPTION
## Summary
- include `aiohttp` in project requirements

## Testing
- `flake8 pro_tg.py tests/test_pro_tg_latency.py`
- `pytest tests/test_pro_tg_latency.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3a3f27e988329981036f49394ac5b