### PR TITLE
Reject capitalized final prepositions

### DIFF
--- a/grammar_filters.py
+++ b/grammar_filters.py
@@ -49,6 +49,10 @@ SINGLE_PAIR_WHITELIST = {
     "i will",
 }
 
+# Prepositions and interrogatives that should not appear capitalised at the
+# end of a sentence unless fully upper-case
+FINAL_TOKEN_PREPOSITIONS = {"of", "from", "where", "when"}
+
 # High entropy patterns ---------------------------------------------------
 SENTENCE_END_PREP_RE = re.compile(
     r"\b(to|by|at|of|in|on)[.!?](?:\s|$)", re.IGNORECASE
@@ -83,6 +87,12 @@ def passes_filters(text: str) -> bool:
         if pair in SINGLE_PAIR_WHITELIST:
             continue
         return False
+    last_word_match = re.search(r"\b(\w+)\W*$", text)
+    if last_word_match:
+        last_word = last_word_match.group(1)
+        if last_word.lower() in FINAL_TOKEN_PREPOSITIONS:
+            if last_word != last_word.lower() and not last_word.isupper():
+                return False
     if SENTENCE_END_PREP_RE.search(text):
         _log(
             "ending-preposition",

--- a/tests/test_final_preposition_casing.py
+++ b/tests/test_final_preposition_casing.py
@@ -1,0 +1,11 @@
+import pytest
+import grammar_filters
+
+
+@pytest.mark.parametrize("word", ["of", "from", "where", "when"])
+def test_final_preposition_casing(word):
+    assert grammar_filters.passes_filters(f"This ends with {word}.")
+    assert not grammar_filters.passes_filters(
+        f"This ends with {word.capitalize()}."
+    )
+    assert grammar_filters.passes_filters(f"This ends with {word.upper()}.")


### PR DESCRIPTION
## Summary
- reject capitalised sentence-ending prepositions unless fully uppercase
- test final preposition casing to cover lowercase and ALL-CAPS

## Testing
- `python -m flake8 grammar_filters.py tests/test_final_preposition_casing.py`
- `PYTHONPATH=. pytest tests/test_articles_and_pronouns.py tests/test_final_preposition_casing.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3a4e64f1c8329bcb663bae19fcbea