### PR TITLE
Await background save tasks in pro_predict

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -509,6 +509,7 @@ class ProEngine:
             tasks.append(self._dream_task)
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+        await pro_predict.wait_save_task()
 
     def compute_charged_words(self, words: List[str]) -> List[str]:
         word_counts = Counter(words)

--- a/tests/test_predict_update.py
+++ b/tests/test_predict_update.py
@@ -26,15 +26,19 @@ def test_predict_learns_new_words(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pro_rag, "retrieve", dummy_retrieve)
 
-    asyncio.run(engine.setup())
-
     new_word = "zzzzword"
     assert new_word not in pro_predict._VECTORS
     before = pro_predict.suggest(new_word)
+    
+    async def run_message():
+        await engine.setup()
+        await engine.process_message(f"{new_word} music")
+        await engine.shutdown()
 
-    asyncio.run(engine.process_message(f"{new_word} music"))
+    asyncio.run(run_message())
 
     assert new_word in pro_predict._VECTORS
     after = pro_predict.suggest(new_word)
     assert after != before
     assert after
+    assert pro_predict._SAVE_TASK is None


### PR DESCRIPTION
## Summary
- track save task in `pro_predict` and ensure it finishes before scheduling new saves
- wait for save tasks during engine shutdown and log any save errors
- test that background save tasks complete after processing messages

## Testing
- `ruff check pro_predict.py pro_engine.py tests/test_predict_update.py`
- `PYTHONPATH=. pytest tests/test_predict_update.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b39dbb49d48329b8d55d18bfd03e69