### PR TITLE
Handle async memory shutdown without asyncio.run lambdas

### DIFF
--- a/pro_memory_pool.py
+++ b/pro_memory_pool.py
@@ -118,4 +118,18 @@ async def execute_cached(
     return rows
 
 
-atexit.register(lambda: asyncio.run(close_pool()))
+def _close_pool_sync() -> None:
+    """Synchronously close the connection pool.
+
+    If an event loop is active, the ``close_pool`` coroutine is scheduled on it.
+    Otherwise, a new event loop is created to run the coroutine to completion.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(close_pool())
+    else:
+        loop.create_task(close_pool())
+
+
+atexit.register(_close_pool_sync)

--- a/tests/test_memory_shutdown.py
+++ b/tests/test_memory_shutdown.py
@@ -1,0 +1,37 @@
+import asyncio
+import pro_memory
+import pro_memory_pool
+import pytest
+
+
+def test_close_pool_sync_no_loop(tmp_path):
+    db = tmp_path / "pool.db"
+    asyncio.run(pro_memory_pool.init_pool(str(db)))
+    pro_memory_pool._close_pool_sync()
+    assert pro_memory_pool._POOL == []
+
+
+@pytest.mark.asyncio
+async def test_close_pool_sync_running_loop(tmp_path):
+    db = tmp_path / "pool_async.db"
+    await pro_memory_pool.init_pool(str(db))
+    pro_memory_pool._close_pool_sync()
+    await asyncio.sleep(0)
+    assert pro_memory_pool._POOL == []
+
+
+def test_close_db_sync_no_loop(tmp_path, monkeypatch):
+    monkeypatch.setattr(pro_memory, "DB_PATH", str(tmp_path / "mem.db"))
+    asyncio.run(pro_memory.init_db())
+    pro_memory._close_db_sync()
+    assert pro_memory_pool._POOL == []
+
+
+@pytest.mark.asyncio
+async def test_close_db_sync_running_loop(tmp_path, monkeypatch):
+    monkeypatch.setattr(pro_memory, "DB_PATH", str(tmp_path / "mem_async.db"))
+    await pro_memory.init_db()
+    pro_memory._close_db_sync()
+    await asyncio.sleep(0)
+    assert pro_memory_pool._POOL == []
+


### PR DESCRIPTION
## Summary
- Replace `atexit` lambdas in `pro_memory` and `pro_memory_pool` with synchronous wrappers that schedule cleanup on the running loop or create a new one.
- Add regression tests verifying cleanup both inside and outside of an event loop.

## Testing
- `python -m py_compile pro_memory.py pro_memory_pool.py tests/test_memory_shutdown.py`
- `pytest tests/test_memory_pool_cache.py tests/test_memory_shutdown.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3ad77c108832983c3cad6685d3271