### PR TITLE
Add exit handler and preposition rule tests

### DIFF
--- a/grammar_filters.py
+++ b/grammar_filters.py
@@ -83,11 +83,12 @@ def passes_filters(text: str) -> bool:
         if pair in SINGLE_PAIR_WHITELIST:
             continue
         return False
-    if SENTENCE_END_PREP_RE.search(text):
-        _log(
-            "ending-preposition",
-            SENTENCE_END_PREP_RE.search(text).group(0).split(),
-        )
+    m = SENTENCE_END_PREP_RE.search(text)
+    if m:
+        token = m.group(0).rstrip(".!?")
+        if not (token.islower() or token.isupper()):
+            return False
+        _log("ending-preposition", m.group(0).split())
     if TO_SEQ_RE.search(text):
         _log("to-sequence", TO_SEQ_RE.search(text).group(0).split())
     return True

--- a/tests/test_memory_shutdown.py
+++ b/tests/test_memory_shutdown.py
@@ -1,7 +1,12 @@
+import os
+import sys
 import asyncio
-import pro_memory
-import pro_memory_pool
-import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pro_memory  # noqa: E402
+import pro_memory_pool  # noqa: E402
+import pytest  # noqa: E402
 
 
 def test_close_pool_sync_no_loop(tmp_path):
@@ -35,3 +40,24 @@ async def test_close_db_sync_running_loop(tmp_path, monkeypatch):
     await asyncio.sleep(0)
     assert pro_memory_pool._POOL == []
 
+
+def test_close_pool_sync_closed_loop(tmp_path):
+    db = tmp_path / "pool_closed.db"
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(pro_memory_pool.init_pool(str(db)))
+    loop.close()
+    asyncio.set_event_loop(loop)
+    pro_memory_pool._close_pool_sync()
+    assert pro_memory_pool._POOL == []
+
+
+def test_close_db_sync_closed_loop(tmp_path, monkeypatch):
+    monkeypatch.setattr(pro_memory, "DB_PATH", str(tmp_path / "mem_closed.db"))
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(pro_memory.init_db())
+    loop.close()
+    asyncio.set_event_loop(loop)
+    pro_memory._close_db_sync()
+    assert pro_memory_pool._POOL == []

--- a/tests/test_terminal_preposition_rule.py
+++ b/tests/test_terminal_preposition_rule.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import grammar_filters  # noqa: E402
+
+
+def test_lowercase_terminal_preposition_allowed():
+    assert grammar_filters.passes_filters("We looked at.")
+
+
+def test_mixed_case_terminal_preposition_disallowed():
+    assert not grammar_filters.passes_filters("We looked At.")
+
+
+def test_uppercase_terminal_preposition_allowed():
+    assert grammar_filters.passes_filters("We looked AT.")


### PR DESCRIPTION
## Summary
- test that DB pool and memory handlers close cleanly even when the default loop is closed
- enforce lowercase terminal prepositions in grammar filters and cover success/failure cases

## Testing
- `python -m flake8 grammar_filters.py tests/test_memory_shutdown.py tests/test_terminal_preposition_rule.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'memory.memristor_cell')*
- `pytest tests/test_memory_shutdown.py tests/test_terminal_preposition_rule.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3b46e0bec8329a33c9bce5e06206b