### PR TITLE
Add timing decorator and latency metrics

### DIFF
--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Utility metrics helpers."""

--- a/metrics/timing.py
+++ b/metrics/timing.py
@@ -1,0 +1,51 @@
+"""Timing utilities for lightweight latency tracking."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import time
+from typing import Any, Callable, Optional, TypeVar
+
+import pro_metrics
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def timed(
+    func: Optional[F] = None, *, name: Optional[str] = None
+) -> Callable[[F], F]:
+    """Decorator to record the execution time of *func*.
+
+    The *name* parameter allows overriding the reported metric label. The
+    decorator works with both synchronous and asynchronous callables.
+    """
+
+    def decorator(f: F) -> F:
+        metric_name = name or f.__qualname__
+        if asyncio.iscoroutinefunction(f):
+            @functools.wraps(f)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                start = time.perf_counter()
+                try:
+                    return await f(*args, **kwargs)
+                finally:
+                    duration = time.perf_counter() - start
+                    pro_metrics.record_latency(metric_name, duration)
+
+            return async_wrapper  # type: ignore[misc]
+        else:
+            @functools.wraps(f)
+            def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                start = time.perf_counter()
+                try:
+                    return f(*args, **kwargs)
+                finally:
+                    duration = time.perf_counter() - start
+                    pro_metrics.record_latency(metric_name, duration)
+
+            return sync_wrapper  # type: ignore[misc]
+
+    if func is None:
+        return decorator
+    return decorator(func)

--- a/pro_engine.py
+++ b/pro_engine.py
@@ -37,6 +37,7 @@ from transformers.blocks import SymbolicReasoner
 from meta_controller import MetaController
 from api import vector_store
 import pro_spawn
+from metrics.timing import timed
 
 STATE_PATH = 'pro_state.json'
 HASH_PATH = 'dataset_sha.json'
@@ -898,6 +899,7 @@ class ProEngine:
         except Exception as exc:  # pragma: no cover - logging side effect
             logging.error("Preparing candidates failed: %s", exc)
 
+    @timed
     async def process_message(self, message: str) -> Tuple[str, Dict]:
         best = pro_meta.best_params()
         self.chaos_factor = best.get("chaos_factor", self.chaos_factor)

--- a/pro_predict.py
+++ b/pro_predict.py
@@ -18,6 +18,7 @@ from transformers.quantum_dropout import quantum_dropout
 from pro_metrics import tokenize, lowercase
 from pro_memory import DB_PATH
 import pro_memory
+from metrics.timing import timed
 
 TRANSFORMER_PATH = "pro_transformer.npz"
 
@@ -164,6 +165,7 @@ async def wait_save_task() -> None:
         _SAVE_TASK = None
 
 
+@timed
 async def update(word_list: List[str]) -> None:
     """Update the co-occurrence graph and vectors with new words.
 


### PR DESCRIPTION
## Summary
- add lightweight timing decorator for synchronous/async functions
- track rolling latency stats and expose logging/CLI output
- instrument ProEngine.process_message and pro_predict.update to record latency

## Testing
- `flake8 metrics/timing.py pro_metrics.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'memory.memristor_cell')*

------
https://chatgpt.com/codex/tasks/task_e_68b3b976d5c88329b379eb8169740344