### PR TITLE
Refactor P2P resonance to asyncio

### DIFF
--- a/tests/test_resonance.py
+++ b/tests/test_resonance.py
@@ -1,18 +1,22 @@
+import asyncio
 import pytest
 
 from trainer import Trainer
 from resonance.p2p_resonance import P2PResonance
 
 
-def test_two_trainers_sync() -> None:
+@pytest.mark.asyncio
+async def test_two_trainers_sync() -> None:
     peer1 = P2PResonance()
     peer2 = P2PResonance()
+    await peer1.start()
+    await peer2.start()
     t1 = Trainer(resonance_peer=peer1)
     t2 = Trainer(resonance_peer=peer2)
-    t1.train_step("w", 1.0)
-    t2.train_step("w", 2.0)
-    peer1.exchange("127.0.0.1", peer2.server_address[1])
+    await asyncio.to_thread(t1.train_step, "w", 1.0)
+    await asyncio.to_thread(t2.train_step, "w", 2.0)
+    await peer1.exchange(*peer2.server_address)
     assert t1.params["w"] == pytest.approx(3.0)
     assert t2.params["w"] == pytest.approx(3.0)
-    peer1.stop()
-    peer2.stop()
+    await peer1.stop()
+    await peer2.stop()


### PR DESCRIPTION
## Summary
- Replace ThreadingTCPServer-based peer network with asyncio streams
- Adapt resonance test to async event loop and thread off synchronous training

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'memory.memristor_cell')*
- `PYTHONPATH=. pytest tests/test_resonance.py tests/test_meta_optimizer.py -q`
- `ruff check resonance/p2p_resonance.py tests/test_resonance.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3cc8ee2e083298ff471eb2dd10fe9