### PR TITLE
Check nvidia-smi availability asynchronously

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -4,6 +4,7 @@ import os
 import hashlib
 import asyncio
 import subprocess
+import shutil
 import math
 import random
 import re
@@ -310,6 +311,8 @@ class ProEngine:
             load = 0.0
         if load > 0.2:
             return False
+        if shutil.which("nvidia-smi") is None:
+            return True
         try:
             out = await asyncio.to_thread(
                 subprocess.check_output,


### PR DESCRIPTION
## Summary
- ensure `_system_idle` skips GPU check when `nvidia-smi` is missing
- keep GPU utilization lookup off the event loop using `asyncio.to_thread`

## Testing
- `python -m py_compile pro_engine.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'memory.memristor_cell')*

------
https://chatgpt.com/codex/tasks/task_e_68b3cf0223b08329b5c4f4e29d2b8e92