### PR TITLE
Use aiohttp for async vector store requests

### DIFF
--- a/api/vector_store.py
+++ b/api/vector_store.py
@@ -1,9 +1,8 @@
-import asyncio
-import json
 import os
 import hashlib
 from typing import List
-from urllib import request
+
+import aiohttp
 
 DEFAULT_URL = os.getenv("VECTOR_STORE_URL")
 
@@ -12,25 +11,21 @@ async def upsert(text: str, embedding: List[float], base_url: str | None = None)
 
     The vector store is expected to expose a JSON API with an ``/upsert``
     endpoint accepting ``{"id": str, "embedding": List[float], "text": str}``.
-    The call is executed in a thread to avoid blocking the event loop.
     """
     base_url = base_url or DEFAULT_URL
     if not base_url:
         return
 
     url = f"{base_url}/upsert"
-    payload = json.dumps({
+    payload = {
         "id": hashlib.sha1(text.encode("utf-8")).hexdigest(),
         "embedding": embedding,
         "text": text,
-    }).encode("utf-8")
+    }
 
-    def _request() -> None:
-        req = request.Request(url, data=payload, headers={"Content-Type": "application/json"})
-        with request.urlopen(req) as resp:  # pragma: no cover - network side effect
-            resp.read()
-
-    await asyncio.to_thread(_request)
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json=payload) as resp:  # pragma: no cover - network side effect
+            await resp.read()
 
 async def query(embedding: List[float], top_k: int = 5, base_url: str | None = None) -> List[str]:
     """Return texts most similar to ``embedding`` from the external store."""
@@ -39,12 +34,9 @@ async def query(embedding: List[float], top_k: int = 5, base_url: str | None = N
         return []
 
     url = f"{base_url}/query"
-    payload = json.dumps({"embedding": embedding, "top_k": top_k}).encode("utf-8")
+    payload = {"embedding": embedding, "top_k": top_k}
 
-    def _request() -> List[str]:
-        req = request.Request(url, data=payload, headers={"Content-Type": "application/json"})
-        with request.urlopen(req) as resp:  # pragma: no cover - network side effect
-            data = json.loads(resp.read().decode("utf-8"))
-        return data.get("texts", [])
-
-    return await asyncio.to_thread(_request)
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json=payload) as resp:  # pragma: no cover - network side effect
+            data = await resp.json()
+    return data.get("texts", [])


### PR DESCRIPTION
## Summary
- replace blocking urllib calls with aiohttp sessions for vector store upsert and query endpoints
- drop asyncio.to_thread wrappers and rely on non-blocking `session.post`
- gracefully return without error when `VECTOR_STORE_URL` is unset

## Testing
- `ruff check api/vector_store.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'memory.memristor_cell')*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1742a50832987b331aa23a7a1ee