### PR TITLE
Add lightweight MoE block with ProEngine adapter and benchmarks

### DIFF
--- a/src/models/transformer.py
+++ b/src/models/transformer.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import numpy as np
 
 from adapters.fractal_adapter import FractalAdapter
-from memory.memristor_cell import MemristorCell
+try:  # pragma: no cover - fallback for different package layouts
+    from memory.memristor_cell import MemristorCell
+except ModuleNotFoundError:  # pragma: no cover
+    from src.memory.memristor_cell import MemristorCell
+from transformers.blocks import LightweightMoEBlock
 
 
 class Transformer:
@@ -17,6 +21,7 @@ class Transformer:
         use_fractal_adapter: bool = False,
         fractal_depth: int = 1,
         use_memristor: bool = False,
+        use_light_moe: bool = False,
     ) -> None:
         self.dim = dim
         self.use_fractal_adapter = use_fractal_adapter
@@ -25,14 +30,21 @@ class Transformer:
         if use_fractal_adapter:
             self.adapter = FractalAdapter(fractal_depth)
         self.memristor = MemristorCell() if use_memristor else None
+        self.light_moe = LightweightMoEBlock(dim) if use_light_moe else None
 
-    def forward(self, hidden_states: np.ndarray) -> np.ndarray:
-        """Return hidden states enriched with optional adapter and memristor."""
+    def forward(
+        self,
+        hidden_states: np.ndarray,
+        adapters: list[dict[str, float]] | None = None,
+    ) -> np.ndarray:
+        """Return hidden states enriched with optional features."""
 
         output = hidden_states
         if self.adapter is not None:
             adapter_vec = self.adapter(hidden_states.shape[-1])
             output = output + adapter_vec
+        if self.light_moe is not None:
+            output = self.light_moe(output, adapters=adapters)
         if self.memristor is not None:
             resistance = self.memristor.step(float(np.mean(output)))
             output = output * resistance

--- a/tests/test_lightweight_moe_benchmark.py
+++ b/tests/test_lightweight_moe_benchmark.py
@@ -1,0 +1,39 @@
+import pathlib
+import sys
+import time
+
+import numpy as np
+
+# Ensure local packages are importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from transformers.blocks import HyperBlock, LightweightMoEBlock
+
+
+def test_lightweight_moe_benchmark():
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal(16, dtype=np.float32)
+    context = rng.standard_normal(16, dtype=np.float32)
+
+    hyper = HyperBlock(16, 16)
+    moe = LightweightMoEBlock(16, num_experts=4, seed=0)
+
+    n = 200
+
+    start = time.perf_counter()
+    for _ in range(n):
+        hyper(x, context)
+    hyper_duration = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(n):
+        moe(x, adapters=[{"bias": 0.1}])
+    moe_duration = time.perf_counter() - start
+
+    hyper_throughput = n / hyper_duration
+    moe_throughput = n / moe_duration
+
+    # Basic sanity checks so the benchmark executes
+    assert hyper_duration > 0 and moe_duration > 0
+    assert hyper_throughput > 0 and moe_throughput > 0
+    # Ensure MoE isn't catastrophically slower than HyperBlock
+    assert moe_duration < hyper_duration * 50

--- a/transformers/blocks/__init__.py
+++ b/transformers/blocks/__init__.py
@@ -12,6 +12,7 @@ from .reasoning import (
     SymbolicReasoner,
 )
 from .hyper_block import HyperBlock
+from .light_moe import LightweightMoEBlock
 
 __all__ = [
     "DynamicContextGate",
@@ -24,4 +25,5 @@ __all__ = [
     "SymbolicNot",
     "SymbolicReasoner",
     "HyperBlock",
+    "LightweightMoEBlock",
 ]

--- a/transformers/blocks/light_moe.py
+++ b/transformers/blocks/light_moe.py
@@ -1,0 +1,50 @@
+import numpy as np
+import numpy.typing as npt
+from typing import Dict, List, Optional
+
+
+class LightweightMoEBlock:
+    """Minimal mixture-of-experts block with optional adapter scaling.
+
+    The block routes inputs to one of ``num_experts`` experts using a
+    lightweight gating network inspired by DeepSeek's mixture-of-experts
+    design.  Adapter weights from :class:`ProEngine` can optionally scale the
+    output, enabling external specialization without retraining the experts.
+    """
+
+    def __init__(self, dim: int, num_experts: int = 4, seed: int | None = None) -> None:
+        self.dim = dim
+        self.num_experts = num_experts
+        rng = np.random.default_rng(seed)
+        self.experts = rng.standard_normal((num_experts, dim, dim), dtype=np.float32)
+        self.gate = rng.standard_normal((dim, num_experts), dtype=np.float32)
+
+    def __call__(
+        self,
+        x: npt.NDArray[np.float32],
+        adapters: Optional[List[Dict[str, float]]] = None,
+    ) -> npt.NDArray[np.float32]:
+        """Apply the selected expert to *x* and scale with *adapters*.
+
+        Parameters
+        ----------
+        x:
+            Input vector of shape ``(dim,)``.
+        adapters:
+            Optional list of adapter weight dictionaries provided by
+            :class:`ProEngine`.  The mean of all bias values is used as a
+            multiplicative scale on the expert output.
+        """
+
+        if x.shape != (self.dim,):
+            raise ValueError(f"expected input of shape ({self.dim},)")
+
+        logits = x @ self.gate
+        expert_idx = int(np.argmax(logits))
+        output = self.experts[expert_idx] @ x
+
+        if adapters:
+            bias_sum = sum(sum(a.values()) for a in adapters)
+            scale = 1.0 + bias_sum / (len(adapters) or 1)
+            output = output * scale
+        return output


### PR DESCRIPTION
## Summary
- implement lightweight mixture-of-experts block with optional adapter scaling
- expose block in transformers and ProEngine for experimentation
- benchmark LightMoE against HyperBlock for latency and throughput

## Testing
- `ruff check transformers/blocks/light_moe.py transformers/blocks/__init__.py src/models/transformer.py pro_engine.py tests/test_lightweight_moe_benchmark.py`
- `pytest tests/test_lightweight_moe_benchmark.py -q`
- `pytest` *(fails: Interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d42a553c8329a2d09777688c97e5