### PR TITLE
Refactor memory pool to use aiosqlite async driver

### DIFF
--- a/tests/test_memory_pool_cache.py
+++ b/tests/test_memory_pool_cache.py
@@ -12,18 +12,14 @@ async def test_execute_cached_ttl(tmp_path):
     db = tmp_path / "cache.db"
     await pro_memory_pool.init_pool(str(db))
     async with pro_memory_pool.get_connection() as conn:
-        await asyncio.to_thread(
-            conn.execute, "INSERT INTO messages(content) VALUES (?)", ("hi",)
-        )
-        await asyncio.to_thread(conn.commit)
+        await conn.execute("INSERT INTO messages(content) VALUES (?)", ("hi",))
+        await conn.commit()
     rows1 = await pro_memory_pool.execute_cached(
         "SELECT content FROM messages", ttl=0.5
     )
     async with pro_memory_pool.get_connection() as conn:
-        await asyncio.to_thread(
-            conn.execute, "INSERT INTO messages(content) VALUES (?)", ("bye",)
-        )
-        await asyncio.to_thread(conn.commit)
+        await conn.execute("INSERT INTO messages(content) VALUES (?)", ("bye",))
+        await conn.commit()
     rows2 = await pro_memory_pool.execute_cached(
         "SELECT content FROM messages", ttl=0.5
     )


### PR DESCRIPTION
## Summary
- refactor memory pool to use aiosqlite-based async connections
- switch memory module to native async database calls
- adjust tests to exercise async driver without threads

## Testing
- `ruff check pro_memory_pool.py pro_memory.py tests/test_memory_pool_cache.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'memory.memristor_cell')*
- `pytest tests/test_memory_pool_cache.py tests/test_memory_shutdown.py tests/test_response.py tests/test_engine_resilience.py tests/test_forbidden_synonyms.py tests/test_memory_vectors.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3d23e03448329af894bed05eb678f