### PR TITLE
Refactor quantum attention backends

### DIFF
--- a/tests/test_quantum_backend.py
+++ b/tests/test_quantum_backend.py
@@ -1,6 +1,10 @@
 import numpy as np
 
-from quantum.attention_backend import QuantumAttentionBackend
+from quantum.attention_backend import (
+    AttentionBackend,
+    QuantumAttentionBackend,
+    create_attention_backend,
+)
 
 
 def test_quantum_attention_backend_shape():
@@ -8,5 +12,17 @@ def test_quantum_attention_backend_shape():
     q = np.ones((2, 4))
     k = np.ones((4, 4))
     v = np.arange(16).reshape(4, 4)
-    out = backend.attention(q[0], k, v)
+    out, betti = backend.attention(q[0], k, v)
     assert out.shape == (4,)
+    assert betti.shape == (2,)
+
+
+def test_backend_factory():
+    backend = create_attention_backend("classical")
+    assert isinstance(backend, AttentionBackend)
+    q = np.ones((1, 4))
+    k = np.ones((4, 4))
+    v = np.arange(16).reshape(4, 4)
+    out, betti = backend.attention(q[0], k, v)
+    assert out.shape == (4,)
+    assert betti.shape == (2,)

--- a/transformers/quantum_attention.py
+++ b/transformers/quantum_attention.py
@@ -6,7 +6,12 @@ experiments and unit tests.
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - only used for typing
+    from quantum.attention_backend import AttentionBackend  # noqa: F401
 
 
 def _count_components(mask: np.ndarray) -> int:
@@ -47,6 +52,9 @@ def _betti_features(amplitudes: np.ndarray) -> np.ndarray:
 
 class QuantumAttention:
     """Simulate a minimal quantum attention mechanism.
+
+    Implements :class:`~quantum.attention_backend.AttentionBackend` using a
+    pure NumPy simulation.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- define AttentionBackend protocol for interchangeable quantum attention implementations
- add runtime factory to select qiskit or classical backend
- ensure both backends return attention output with Betti features

## Testing
- `ruff check quantum/attention_backend.py transformers/quantum_attention.py tests/test_quantum_backend.py`
- `pytest tests/quantum/test_quantum_attention.py tests/test_quantum_backend.py tests/test_quantum_hybrid_attention.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3dd8a790083298987e606356f9fa2