### PR TITLE
Refactor suggest to async

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -685,9 +685,7 @@ class ProEngine:
         analog_lock = asyncio.Lock()
 
         async def _build_analog(tok: str) -> None:
-            suggestions = await asyncio.to_thread(
-                pro_predict.suggest, tok, topn=1
-            )
+            suggestions = await pro_predict.suggest_async(tok, topn=1)
             analog = suggestions[0] if suggestions else None
             if not analog:
                 analog = await asyncio.to_thread(pro_predict.lookup_analogs, tok)
@@ -999,9 +997,7 @@ class ProEngine:
         unknown: List[str] = [
             w for w in words if w not in self.state['word_counts']
         ]
-        suggest_tasks = [
-            asyncio.to_thread(pro_predict.suggest, w) for w in unknown
-        ]
+        suggest_tasks = [pro_predict.suggest_async(w) for w in unknown]
         predicted: List[str] = []
         if suggest_tasks:
             for suggestions in await asyncio.gather(*suggest_tasks):

--- a/tests/test_forbidden_synonyms.py
+++ b/tests/test_forbidden_synonyms.py
@@ -21,7 +21,15 @@ def test_forbidden_words_replaced(tmp_path, monkeypatch):
         "bar": 4,
         "baz": 5,
     }
-    monkeypatch.setattr(pro_predict, "suggest", lambda w, topn=3: {"hello": ["hi"], "world": ["earth"]}.get(w, []))
+    async def fake_suggest_async(w, topn=3):
+        return {"hello": ["hi"], "world": ["earth"]}.get(w, [])
+
+    monkeypatch.setattr(pro_predict, "suggest_async", fake_suggest_async)
+    monkeypatch.setattr(
+        pro_predict,
+        "suggest",
+        lambda w, topn=3: asyncio.run(fake_suggest_async(w, topn)),
+    )
     monkeypatch.setattr(pro_predict, "lookup_analogs", lambda w: None)
     monkeypatch.setattr(pro_predict, "_VECTORS", {
         "hi": {"a": 1.0},

--- a/tests/test_predict_update.py
+++ b/tests/test_predict_update.py
@@ -28,7 +28,7 @@ def test_predict_learns_new_words(tmp_path, monkeypatch):
 
     new_word = "zzzzword"
     assert new_word not in pro_predict._VECTORS
-    before = pro_predict.suggest(new_word)
+    before = asyncio.run(pro_predict.suggest_async(new_word))
     
     async def run_message():
         await engine.setup()
@@ -38,7 +38,7 @@ def test_predict_learns_new_words(tmp_path, monkeypatch):
     asyncio.run(run_message())
 
     assert new_word in pro_predict._VECTORS
-    after = pro_predict.suggest(new_word)
+    after = asyncio.run(pro_predict.suggest_async(new_word))
     assert after != before
     assert after
     assert pro_predict._SAVE_TASK is None

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -332,6 +332,11 @@ def test_respond_latency(tmp_path, monkeypatch):
         return None
 
     monkeypatch.setattr(pro_predict, "_ensure_vectors", _noop)
+
+    async def _suggest_noop(*a, **k):
+        return []
+
+    monkeypatch.setattr(pro_predict, "suggest_async", _suggest_noop)
     monkeypatch.setattr(pro_predict, "suggest", lambda *a, **k: [])
     real_exists = os.path.exists
     monkeypatch.setattr(

--- a/tests/test_uppercase_preservation.py
+++ b/tests/test_uppercase_preservation.py
@@ -47,6 +47,10 @@ def engine(monkeypatch):
         "soon": ["shortly"],
     }
 
+    async def fake_suggest_async(w, topn=3, _m=mapping):
+        return _m.get(w.lower(), [])
+
+    monkeypatch.setattr(pro_predict, "suggest_async", fake_suggest_async)
     monkeypatch.setattr(
         pro_predict, "suggest", lambda w, topn=3, _m=mapping: _m.get(w.lower(), [])
     )


### PR DESCRIPTION
## Summary
- introduce async `suggest_async` for vector lookup and use wrapper `suggest`
- await `suggest_async` from engine and tests

## Testing
- `ruff check pro_predict.py pro_engine.py tests/test_predict_update.py tests/test_forbidden_synonyms.py tests/test_uppercase_preservation.py tests/test_response.py`
- `pytest` *(failed: hung during run)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e290f2a48329801692ab5a4e05c8