### PR TITLE
Load dream prompts from configurable file

### DIFF
--- a/dream_data.json
+++ b/dream_data.json
@@ -1,0 +1,12 @@
+{
+  "prompts": [
+    "imagine a city that floats on clouds",
+    "what happens when clocks dream?",
+    "describe a world powered by laughter"
+  ],
+  "responses": [
+    "The city drifts quietly above the horizon, tethered by beams of light.",
+    "Sleeping clocks tick in poetry, measuring moments that never were.",
+    "In that world, every giggle lights a lantern in the sky."
+  ]
+}

--- a/dream_mode.py
+++ b/dream_mode.py
@@ -1,40 +1,73 @@
 """Background dreaming mode generating synthetic dialogues."""
 
+from __future__ import annotations
+
+import json
 import random
-from typing import List
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pro_memory
 from trainer import Trainer
 
-_PROMPTS = [
-    "hello there",
-    "how are you",
-    "tell me a story",
-    "what is your favorite color",
-    "do you like music",
-]
+try:  # Optional YAML support
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
 
-_RESPONSES = [
-    "I am just code, but I am functioning well",
-    "once upon a time a small bot dreamed",
-    "I like all colors equally",
-    "music is delightful even for code",
-    "thanks for asking",
-]
+_DEFAULT_DATA = {
+    "prompts": [
+        "describe a surreal landscape",
+        "share a quirky dream snippet",
+        "what would clouds say if they could speak?",
+    ],
+    "responses": [
+        "In dreams, the impossible folds into reality.",
+        "I wandered through a maze of luminous equations.",
+        "Clouds might whisper secrets about changing shapes.",
+    ],
+}
+
+_DEFAULT_DATA_FILE = Path(__file__).with_name("dream_data.json")
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from pro_engine import ProEngine
 
 
-def _simulate_dialogue(turns: int = 3) -> List[str]:
+def _load_dialogue_data(
+    path: str | None = None,
+) -> tuple[list[str], list[str]]:
+    """Load prompts and responses from JSON or YAML."""
+    data_path = Path(path) if path else _DEFAULT_DATA_FILE
+    if data_path.is_file():
+        with data_path.open("r", encoding="utf-8") as f:
+            if data_path.suffix.lower() in {".yml", ".yaml"} and yaml:
+                data = yaml.safe_load(f)
+            else:
+                data = json.load(f)
+        prompts = data.get("prompts", _DEFAULT_DATA["prompts"])
+        responses = data.get("responses", _DEFAULT_DATA["responses"])
+        return prompts, responses
+    return _DEFAULT_DATA["prompts"], _DEFAULT_DATA["responses"]
+
+
+def _simulate_dialogue(
+    turns: int = 3, data_path: str | None = None
+) -> list[str]:
     """Generate a simple alternating dialogue."""
-    dialogue: List[str] = []
+    prompts, responses = _load_dialogue_data(data_path)
+    dialogue: list[str] = []
     for _ in range(turns):
-        dialogue.append(random.choice(_PROMPTS))
-        dialogue.append(random.choice(_RESPONSES))
+        dialogue.append(random.choice(prompts))
+        dialogue.append(random.choice(responses))
     return dialogue
 
 
-async def run(engine: "ProEngine", turns: int = 3) -> None:
+async def run(
+    engine: ProEngine, turns: int = 3, data_path: str | None = None
+) -> None:
     """Generate dialogue and route through the training loop."""
-    dialogue = _simulate_dialogue(turns)
+    dialogue = _simulate_dialogue(turns, data_path=data_path)
     trainer = Trainer()
     trainer.evolve("dream", dialogue, metric=1.0)
     for line in dialogue:

--- a/tests/test_dream_mode.py
+++ b/tests/test_dream_mode.py
@@ -1,0 +1,10 @@
+import json
+import dream_mode
+
+
+def test_simulate_dialogue_uses_external_data(tmp_path):
+    data = {"prompts": ["hi"], "responses": ["bye"]}
+    data_file = tmp_path / "data.json"
+    data_file.write_text(json.dumps(data))
+    dialogue = dream_mode._simulate_dialogue(turns=1, data_path=str(data_file))
+    assert dialogue == ["hi", "bye"]


### PR DESCRIPTION
## Summary
- Load dream-mode prompts and responses from a JSON/YAML file with sensible defaults
- Support optional data path for simulation and runtime execution
- Add test covering configurable dialogue data

## Testing
- `python -m flake8 dream_mode.py tests/test_dream_mode.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3ee7958088329be3489f80aa0d5e3