### PR TITLE
feat: cache external retrieval and handle timeout

### DIFF
--- a/tests/test_retrieve_external.py
+++ b/tests/test_retrieve_external.py
@@ -12,6 +12,7 @@ import pro_rag  # noqa: E402
 
 @pytest.mark.asyncio
 async def test_retrieve_external_success(monkeypatch):
+    pro_rag._external_cache.clear()
     app = web.Application()
 
     async def handler(request):
@@ -33,6 +34,7 @@ async def test_retrieve_external_success(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_retrieve_external_timeout(monkeypatch):
+    pro_rag._external_cache.clear()
     app = web.Application()
 
     async def handler(request):
@@ -52,3 +54,30 @@ async def test_retrieve_external_timeout(monkeypatch):
     finally:
         await runner.cleanup()
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_retrieve_external_cache(monkeypatch):
+    pro_rag._external_cache.clear()
+    app = web.Application()
+    calls = {"count": 0}
+
+    async def handler(request):
+        calls["count"] += 1
+        return web.json_response(["test", [], ["desc"], []])
+
+    app.router.add_get("/", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "localhost", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    monkeypatch.setenv("WIKIPEDIA_API", f"http://localhost:{port}")
+    try:
+        result1 = await pro_rag.retrieve_external("cache")
+        result2 = await pro_rag.retrieve_external("cache")
+    finally:
+        await runner.cleanup()
+    assert result1 == ["desc"]
+    assert result2 == ["desc"]
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- cache results in `retrieve_external`
- lower external timeout and handle task cancellation
- test caching behavior for external retrieval

## Testing
- `flake8 pro_rag.py tests/test_retrieve_external.py`
- `pytest tests/test_retrieve_external.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3f2a3efb88329a713f8d3c8d7239a