### PR TITLE
Flush meta recompute tasks on shutdown

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -525,6 +525,7 @@ class ProEngine:
         if self._running_tasks:
             await asyncio.gather(*self._running_tasks, return_exceptions=True)
         await pro_predict.wait_save_task()
+        await pro_meta.wait_recompute()
 
     def compute_charged_words(self, words: List[str]) -> List[str]:
         word_counts = Counter(words)


### PR DESCRIPTION
## Summary
- track pro_meta recompute tasks and expose wait_recompute
- await meta recompute in ProEngine.shutdown

## Testing
- `ruff check pro_meta.py pro_engine.py`
- `pytest tests/test_meta_optimizer.py tests/test_memory_shutdown.py tests/test_predict_update.py -q` *(fails: ModuleNotFoundError: No module named 'trainer')*

------
https://chatgpt.com/codex/tasks/task_e_68b3ff6a090083299a2f9bd8acc370b5