### PR TITLE
refactor dream_mode to load dynamic prompts

### DIFF
--- a/dream_mode.py
+++ b/dream_mode.py
@@ -1,40 +1,55 @@
 """Background dreaming mode generating synthetic dialogues."""
 
 import random
-from typing import List
+from pathlib import Path
+from typing import List, Optional, Sequence
 
 import pro_memory
 from trainer import Trainer
 
-_PROMPTS = [
-    "hello there",
-    "how are you",
-    "tell me a story",
-    "what is your favorite color",
-    "do you like music",
-]
-
-_RESPONSES = [
-    "I am just code, but I am functioning well",
-    "once upon a time a small bot dreamed",
-    "I like all colors equally",
-    "music is delightful even for code",
-    "thanks for asking",
-]
+DEFAULT_DATASET = "datasets/smalltalk.txt"
 
 
-def _simulate_dialogue(turns: int = 3) -> List[str]:
-    """Generate a simple alternating dialogue."""
+def _load_corpus(path: str) -> List[str]:
+    """Load a list of utterances from ``path``.
+
+    Each non-empty line in the file becomes a candidate utterance. If the file
+    does not exist, an empty list is returned so callers can handle the lack of
+    data gracefully.
+    """
+
+    p = Path(path)
+    if not p.exists():
+        return []
+    return [line.strip() for line in p.read_text().splitlines() if line.strip()]
+
+
+def _simulate_dialogue(
+    turns: int = 3, corpus: Optional[Sequence[str]] = None
+) -> List[str]:
+    """Generate a simple alternating dialogue from a dynamic corpus."""
+
+    lines: Sequence[str]
+    if corpus is None:
+        lines = _load_corpus(DEFAULT_DATASET)
+    else:
+        lines = corpus
+    if not lines:
+        return []
     dialogue: List[str] = []
     for _ in range(turns):
-        dialogue.append(random.choice(_PROMPTS))
-        dialogue.append(random.choice(_RESPONSES))
+        dialogue.append(random.choice(lines))
+        dialogue.append(random.choice(lines))
     return dialogue
 
 
-async def run(engine: "ProEngine", turns: int = 3) -> None:
+async def run(
+    engine: "ProEngine", turns: int = 3, dataset_path: Optional[str] = None
+) -> None:
     """Generate dialogue and route through the training loop."""
-    dialogue = _simulate_dialogue(turns)
+
+    corpus = _load_corpus(dataset_path or DEFAULT_DATASET)
+    dialogue = _simulate_dialogue(turns, corpus)
     trainer = Trainer()
     trainer.evolve("dream", dialogue, metric=1.0)
     for line in dialogue:


### PR DESCRIPTION
## Summary
- remove hardcoded prompt/response templates
- dynamically load utterances from a configurable dataset
- update dream mode dialogue generation to draw from dynamic corpus

## Testing
- `python -m py_compile dream_mode.py`
- `flake8 dream_mode.py` *(fails: command not found)*
- `pytest tests/test_async_round_trip_latency.py::test_dream_worker_quick_startup -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3f161a42c8329ab7a91d2c5ca7def