### PR TITLE
feat: detect similar responses

### DIFF
--- a/tests/test_memory_unique.py
+++ b/tests/test_memory_unique.py
@@ -1,0 +1,15 @@
+import asyncio
+
+import pro_memory
+
+
+def test_is_unique_near_duplicate(tmp_path, monkeypatch):
+    db_path = tmp_path / "mem.db"
+    monkeypatch.setattr(pro_memory, "DB_PATH", str(db_path))
+    asyncio.run(pro_memory.init_db())
+
+    asyncio.run(pro_memory.store_response("hello world"))
+
+    assert not asyncio.run(pro_memory.is_unique("hello world"))
+    assert not asyncio.run(pro_memory.is_unique("Hello world!"))
+    assert asyncio.run(pro_memory.is_unique("something else entirely"))


### PR DESCRIPTION
## Summary
- use Jaccard similarity over token trigrams to detect near-duplicate responses in memory
- add regression test covering near-duplicate responses

## Testing
- `PYTHONPATH=. pytest tests/test_response.py::test_duplicate_responses_suppressed -q`
- `PYTHONPATH=. pytest tests/test_memory_unique.py -q`
- `python -m py_compile pro_memory.py tests/test_memory_unique.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4176a2e788329809b715f54adae6d