### PR TITLE
feat: make dream worker optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Phrase collections stored for training runs. They form the base for learning cyc
 
 Streams file changes to the engine without blocking. New lines appear as soon as they are saved. It also streamlines future extensions.
 
+### Dream Mode
+
+Generates synthetic dialogues in the background to keep the model fresh. Each run is timed and recorded for latency metrics. On resource‑constrained systems this worker can introduce extra load; disable it with `--no-dream-worker` or schedule runs explicitly with `--dream-schedule <seconds>`.
+
 ### Caching and Pooling
 
 Shared helpers keep memory operations efficient under load. The engine calls them for every memory task. This choice facilitates ongoing refinement.

--- a/dream_mode.py
+++ b/dream_mode.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import pro_memory
 from trainer import Trainer
+from metrics.timing import timed
 
 try:  # Optional YAML support
     import yaml  # type: ignore
@@ -65,6 +66,7 @@ def _simulate_dialogue(
     return dialogue
 
 
+@timed(name="dream_mode.run")
 async def run(
     engine: ProEngine, turns: int = 3, data_path: str | None = None
 ) -> None:


### PR DESCRIPTION
## Summary
- allow disabling background dream worker and support scheduled runs
- record dream-mode latency metrics and expose CLI flags
- document dream mode's latency impact

## Testing
- `ruff check pro_engine.py dream_mode.py`
- `pytest` *(fails: KeyboardInterrupt)*
- `PYTHONPATH=. pytest tests/test_dream_mode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41c36511c8329baef4e5e5fa5e8c9