### PR TITLE
Defer qiskit import and validate backend availability

### DIFF
--- a/quantum/attention_backend.py
+++ b/quantum/attention_backend.py
@@ -5,10 +5,6 @@ from __future__ import annotations
 from typing import Protocol, runtime_checkable
 
 import numpy as np
-try:  # pragma: no cover - optional import for docs
-    from qiskit import Aer, QuantumCircuit, execute
-except Exception:  # pragma: no cover - allow tests without qiskit
-    Aer = QuantumCircuit = execute = None  # type: ignore
 
 
 @runtime_checkable
@@ -31,23 +27,20 @@ class QuantumAttentionBackend:
     """
 
     def __init__(self, shots: int = 256, backend_name: str = "aer_simulator") -> None:
+        from qiskit import Aer, QuantumCircuit, execute  # type: ignore[import-not-found]
+
         self.shots = shots
-        if Aer is not None:
-            self.backend = Aer.get_backend(backend_name)
-        else:  # pragma: no cover - qiskit not installed
-            self.backend = None
+        self.backend = Aer.get_backend(backend_name)
+        self._qc = QuantumCircuit
+        self._execute = execute
 
     def _prob(self, score: float) -> float:
         """Return probability of measuring |1> for a given score."""
-        if QuantumCircuit is None or self.backend is None:
-            # Fall back to a classical sigmoid if qiskit is unavailable
-            return float(1 / (1 + np.exp(-score)))
-
         angle = float(np.tanh(score))  # map score to a bounded angle
-        qc = QuantumCircuit(1, 1)
+        qc = self._qc(1, 1)
         qc.ry(2 * angle, 0)
         qc.measure(0, 0)
-        job = execute(qc, backend=self.backend, shots=self.shots)
+        job = self._execute(qc, backend=self.backend, shots=self.shots)
         counts = job.result().get_counts()
         return counts.get("1", 0) / self.shots
 
@@ -77,7 +70,12 @@ def create_attention_backend(name: str, **kwargs) -> AttentionBackend:
     """
 
     if name == "qiskit":
-        return QuantumAttentionBackend(**kwargs)
+        try:
+            return QuantumAttentionBackend(**kwargs)
+        except ImportError as exc:  # pragma: no cover - handled in tests
+            raise RuntimeError(
+                "qiskit backend selected but the 'qiskit' package is not installed"
+            ) from exc
     if name == "classical":
         from transformers.quantum_attention import QuantumAttention
 

--- a/tests/test_quantum_backend.py
+++ b/tests/test_quantum_backend.py
@@ -1,4 +1,6 @@
+import importlib.util
 import numpy as np
+import pytest
 
 from quantum.attention_backend import (
     AttentionBackend,
@@ -8,6 +10,8 @@ from quantum.attention_backend import (
 
 
 def test_quantum_attention_backend_shape():
+    pytest.importorskip("qiskit")
+    pytest.importorskip("qiskit_aer")
     backend = QuantumAttentionBackend(shots=16)
     q = np.ones((2, 4))
     k = np.ones((4, 4))
@@ -26,3 +30,15 @@ def test_backend_factory():
     out, betti = backend.attention(q[0], k, v)
     assert out.shape == (4,)
     assert betti.shape == (2,)
+
+
+def test_backend_factory_requires_qiskit():
+    if (
+        importlib.util.find_spec("qiskit") is None
+        or importlib.util.find_spec("qiskit_aer") is None
+    ):
+        with pytest.raises(RuntimeError):
+            create_attention_backend("qiskit")
+    else:
+        backend = create_attention_backend("qiskit")
+        assert isinstance(backend, QuantumAttentionBackend)

--- a/tests/test_quantum_hybrid_attention.py
+++ b/tests/test_quantum_hybrid_attention.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from quantum.attention_backend import QuantumAttentionBackend
 from router.policy import PatchRoutingPolicy
@@ -6,6 +7,8 @@ from transformers.modeling_transformer import QuantumHybridAttention
 
 
 def test_quantum_hybrid_attention_routes():
+    pytest.importorskip("qiskit")
+    pytest.importorskip("qiskit_aer")
     backend = QuantumAttentionBackend(shots=16)
     policy = PatchRoutingPolicy(dim=1, seed=0)
     attention = QuantumHybridAttention(policy, backend)


### PR DESCRIPTION
## Summary
- import qiskit only inside `QuantumAttentionBackend.__init__`
- raise a clear error when selecting the qiskit backend without the package
- adjust quantum tests to skip or check when qiskit and qiskit_aer aren't present

## Testing
- `PYTHONPATH=. pytest tests/test_quantum_backend.py tests/test_quantum_hybrid_attention.py -q`
- `flake8 quantum/attention_backend.py tests/test_quantum_backend.py tests/test_quantum_hybrid_attention.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4310d24a483298cf2aae30f9aa1a4