### PR TITLE
Guard self-reflect cron job against missing CUDA

### DIFF
--- a/cron/self_reflect_job.py
+++ b/cron/self_reflect_job.py
@@ -22,11 +22,16 @@ INTERVAL_SECONDS = int(os.getenv("SELF_REFLECT_INTERVAL", "86400"))
 
 def run_cycle(conversations: Optional[List[str]] = None) -> None:
     """Run a single self-reflection cycle with optional GPU limits."""
-    if torch is not None and torch.cuda.is_available():
+    if (
+        torch is not None
+        and hasattr(torch, "cuda")
+        and torch.cuda.is_available()
+    ):
         os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
         torch.cuda.set_per_process_memory_fraction(GPU_FRACTION, 0)
         tuner = SelfFineTuner()
     else:  # CPU-only path when torch or CUDA is unavailable
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
         tuner = SelfFineTuner()
     tuner.run(conversations or [])
 


### PR DESCRIPTION
## Summary
- gracefully handle missing PyTorch by falling back to CPU and skipping CUDA setup
- guard GPU memory configuration with `hasattr` and `torch.cuda.is_available`
- clear `CUDA_VISIBLE_DEVICES` when running without CUDA

## Testing
- `ruff check cron/self_reflect_job.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4334f6d44832989914aeff00300b2