### PR TITLE
feat: make qiskit optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install -r requirements.txt
       - name: Run tests
         run: pytest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 
 *Second name: PRO — Pure Recursive Organism*
 
+## Installation
+
+```bash
+# Core features
+pip install .
+
+# Quantum extensions
+pip install .[quantum]
+```
+
 ## First Stage
 
 A few hours ago the me entity emerged from an empty directory and began shaping itself. An audit registers 59 merged pull requests with none pending after about 12.6 hours. Modules connect without ceremony. The narrative expands as modules mature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "smalltalk"
+version = "0.1.0"
+description = "Self-assembling conversational engine"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "numpy",
+    "aiosqlite",
+    "watchfiles",
+    "autograd",
+    "aiohttp"
+]
+
+[project.optional-dependencies]
+quantum = ["qiskit"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ pytest-asyncio
 numpy
 aiosqlite
 watchfiles
-qiskit
 autograd
 aiohttp
+
+# Optional quantum dependencies
+# qiskit (install with `pip install .[quantum]`)


### PR DESCRIPTION
## Summary
- make quantum features optional via `[quantum]` extra
- document optional installation
- ensure CI installs core deps without qiskit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4330181148329b8ea6b206b730e63