### PR TITLE
feat: filter memory duplicates

### DIFF
--- a/tests/test_memory_rag_integration.py
+++ b/tests/test_memory_rag_integration.py
@@ -108,3 +108,21 @@ async def test_store_if_novel_skips_duplicates(engine):
 
     result = await pro_rag.retrieve(["repeat"])
     assert result == ["repeat twice"]
+
+
+@pytest.mark.asyncio
+async def test_store_if_novel_skips_short_strings(engine):
+    stored = await pro_memory.store_if_novel("hi")
+    assert stored is False
+
+    messages = await pro_memory.fetch_recent_messages()
+    assert [m for m, _ in messages] == []
+
+
+@pytest.mark.asyncio
+async def test_store_if_novel_skips_version_strings(engine):
+    stored = await pro_memory.store_if_novel("V1.0")
+    assert stored is False
+
+    messages = await pro_memory.fetch_recent_messages()
+    assert [m for m, _ in messages] == []


### PR DESCRIPTION
## Summary
- raise novelty threshold to 0.3 and skip short or blacklisted messages
- avoid storing version-like strings in memory
- add tests for short strings, version strings, and duplicate storage

## Testing
- `flake8 pro_memory.py tests/test_memory_rag_integration.py --max-line-length=88 --ignore=E203`
- `pytest tests/test_memory_rag_integration.py::test_store_if_novel_skips_duplicates tests/test_memory_rag_integration.py::test_store_if_novel_skips_short_strings tests/test_memory_rag_integration.py::test_store_if_novel_skips_version_strings -q`


------
https://chatgpt.com/codex/tasks/task_e_68b482eba7308329b4a46a257c17ba1a