### PR TITLE
Filter duplicate candidates

### DIFF
--- a/tests/test_candidate_dedup.py
+++ b/tests/test_candidate_dedup.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+import pro_engine
+
+
+def test_filter_similar_candidates_removes_duplicates():
+    emb1 = np.array([1.0, 0.0], dtype=float)
+    emb2 = np.array([0.99, 0.01], dtype=float)
+    emb3 = np.array([-1.0, 0.0], dtype=float)
+    cands = [(emb1, "foo"), (emb2, "foo"), (emb3, "bar")]
+    filtered = pro_engine.filter_similar_candidates(cands, threshold=0.98)
+    texts = [t for _, t in filtered]
+    assert len(filtered) == 2
+    assert len(set(texts)) == len(texts)
+
+
+def test_rank_candidates_no_duplicate_topn():
+    engine = pro_engine.ProEngine()
+    engine.candidate_buffer.clear()
+    emb1 = np.array([1.0, 0.0], dtype=float)
+    emb2 = np.array([0.99, 0.01], dtype=float)
+    emb3 = np.array([-1.0, 0.0], dtype=float)
+    engine.candidate_buffer.append((emb1, "foo"))
+    engine.candidate_buffer.append((emb2, "foo"))
+    engine.candidate_buffer.append((emb3, "bar"))
+    ranked = engine.rank_candidates(np.array([1.0, 0.0], dtype=float), topn=2)
+    responses = [resp for _, _, resp in ranked]
+    assert len(responses) == 2
+    assert len(set(responses)) == len(responses)


### PR DESCRIPTION
## Summary
- dedupe candidate responses using cosine distance
- penalize overused template phrases like "V2.0"
- add unit tests ensuring top-N candidate responses contain no duplicates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b486eb3cd483298b9d954576f981e9