### PR TITLE
Use CPU metrics for idle detection

### DIFF
--- a/tests/test_system_idle_cpu.py
+++ b/tests/test_system_idle_cpu.py
@@ -1,0 +1,29 @@
+import asyncio
+import pytest
+
+import pro_engine
+from pro_engine import ProEngine
+
+
+@pytest.mark.asyncio
+async def test_system_idle_true(monkeypatch):
+    samples = iter([(100, 200), (190, 300)])
+
+    def fake_read_cpu_times():
+        return next(samples)
+
+    monkeypatch.setattr(pro_engine, "_read_cpu_times", fake_read_cpu_times)
+    engine = ProEngine()
+    assert await engine._system_idle()
+
+
+@pytest.mark.asyncio
+async def test_system_idle_false(monkeypatch):
+    samples = iter([(100, 200), (110, 220)])
+
+    def fake_read_cpu_times():
+        return next(samples)
+
+    monkeypatch.setattr(pro_engine, "_read_cpu_times", fake_read_cpu_times)
+    engine = ProEngine()
+    assert not await engine._system_idle()


### PR DESCRIPTION
## Summary
- rely on CPU time deltas from /proc/stat to determine system idleness
- drop nvidia-smi GPU utilization checks
- add tests covering CPU-only idle detection logic

## Testing
- `python -m ruff check pro_engine.py tests/test_system_idle_cpu.py`
- `pytest tests/test_system_idle_cpu.py tests/test_async_round_trip_latency.py::test_dream_worker_quick_startup -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b23e3b948329818aea3279a9aa1b