### PR TITLE
Replace torch TransformerBlock with NumPy

### DIFF
--- a/src/models/transformer_block.py
+++ b/src/models/transformer_block.py
@@ -1,31 +1,44 @@
-"""Simplified transformer block that can use complex attention."""
+"""Simplified transformer block implemented with NumPy."""
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
-from typing import Dict, Any
+from typing import Any, Dict
 
-try:  # pragma: no cover - optional dependency
-    import torch
-    from torch import nn
-except ModuleNotFoundError:  # pragma: no cover - handled in tests
-    torch = None
-    nn = object  # type: ignore[misc,assignment]
+import numpy as np
 
 from attention import ComplexAttention
 
 
+def _softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
+    """Return the softmax of ``x`` along ``axis``."""
+    e_x = np.exp(x - np.max(x, axis=axis, keepdims=True))
+    return e_x / np.sum(e_x, axis=axis, keepdims=True)
+
+
+class Linear:
+    """Minimal linear layer backed by NumPy arrays."""
+
+    def __init__(self, in_features: int, out_features: int) -> None:
+        rng = np.random.default_rng()
+        self.weight = rng.standard_normal((out_features, in_features))
+        self.bias = np.zeros(out_features)
+
+    def __call__(self, x: np.ndarray) -> np.ndarray:
+        return x @ self.weight.T + self.bias
+
+    def state_dict(self) -> Dict[str, np.ndarray]:
+        return {"weight": self.weight, "bias": self.bias}
+
+    def load_state_dict(self, state: Dict[str, np.ndarray]) -> None:
+        self.weight = state["weight"]
+        self.bias = state["bias"]
+
+
 @dataclass
 class TransformerBlockConfig:
-    """Configuration for :class:`TransformerBlock`.
-
-    Parameters
-    ----------
-    dim: int
-        Dimensionality of the input embeddings.
-    use_complex_attention: bool, optional
-        Whether to enable :class:`ComplexAttention` inside the block.
-    """
+    """Configuration for :class:`TransformerBlock`."""
 
     dim: int
     use_complex_attention: bool = False
@@ -36,29 +49,72 @@ class TransformerBlockConfig:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TransformerBlockConfig":
-        """Instantiate config from ``data``.
-
-        Missing ``use_complex_attention`` defaults to ``False`` for backwards
-        compatibility.
-        """
+        """Instantiate config from ``data``."""
         return cls(dim=int(data["dim"]), use_complex_attention=bool(data.get("use_complex_attention", False)))
 
 
-class TransformerBlock(nn.Module if torch else object):  # type: ignore[misc]
-    """Very small transformer block wrapper."""
+class TransformerBlock:
+    """Very small transformer block using NumPy operations."""
 
-    def __init__(self, config: TransformerBlockConfig) -> None:  # pragma: no cover - simple wiring
-        if torch is None:
-            raise ModuleNotFoundError("torch is required for TransformerBlock")
-        super().__init__()
+    def __init__(self, config: TransformerBlockConfig) -> None:
         self.config = config
-        self.attention = (
-            ComplexAttention(config.dim) if config.use_complex_attention else None
-        )
+        dim = config.dim
+        if config.use_complex_attention:
+            self.attention: ComplexAttention | None = ComplexAttention(dim)
+            self.q_proj = self.k_proj = self.v_proj = self.out_proj = None
+        else:
+            self.attention = None
+            self.q_proj = Linear(dim, dim)
+            self.k_proj = Linear(dim, dim)
+            self.v_proj = Linear(dim, dim)
+            self.out_proj = Linear(dim, dim)
 
-    def forward(self, hidden_states: "torch.Tensor") -> "torch.Tensor":  # pragma: no cover - thin wrapper
+    def forward(self, hidden_states: np.ndarray) -> np.ndarray:
         if self.attention is not None:
             return self.attention(hidden_states)
-        return hidden_states
+        q = self.q_proj(hidden_states)
+        k = self.k_proj(hidden_states)
+        v = self.v_proj(hidden_states)
+        scores = np.matmul(q, np.swapaxes(k, -2, -1)) / math.sqrt(self.config.dim)
+        weights = _softmax(scores, axis=-1)
+        out = np.matmul(weights, v)
+        return self.out_proj(out)
 
     __call__ = forward
+
+    def state_dict(self) -> Dict[str, Any]:
+        state: Dict[str, Any] = {"config": self.config.to_dict()}
+        if self.attention is not None:
+            state["attention"] = {
+                "q_proj": {"weight": self.attention.q_proj.weight, "bias": self.attention.q_proj.bias},
+                "k_proj": {"weight": self.attention.k_proj.weight, "bias": self.attention.k_proj.bias},
+                "v_proj": {"weight": self.attention.v_proj.weight, "bias": self.attention.v_proj.bias},
+                "out_proj": {"weight": self.attention.out_proj.weight, "bias": self.attention.out_proj.bias},
+            }
+        else:
+            state.update(
+                {
+                    "q_proj": self.q_proj.state_dict(),
+                    "k_proj": self.k_proj.state_dict(),
+                    "v_proj": self.v_proj.state_dict(),
+                    "out_proj": self.out_proj.state_dict(),
+                }
+            )
+        return state
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        if self.attention is not None and "attention" in state:
+            att = state["attention"]
+            self.attention.q_proj.weight = att["q_proj"]["weight"]
+            self.attention.q_proj.bias = att["q_proj"]["bias"]
+            self.attention.k_proj.weight = att["k_proj"]["weight"]
+            self.attention.k_proj.bias = att["k_proj"]["bias"]
+            self.attention.v_proj.weight = att["v_proj"]["weight"]
+            self.attention.v_proj.bias = att["v_proj"]["bias"]
+            self.attention.out_proj.weight = att["out_proj"]["weight"]
+            self.attention.out_proj.bias = att["out_proj"]["bias"]
+        else:
+            self.q_proj.load_state_dict(state["q_proj"])
+            self.k_proj.load_state_dict(state["k_proj"])
+            self.v_proj.load_state_dict(state["v_proj"])
+            self.out_proj.load_state_dict(state["out_proj"])

--- a/tests/test_transformer_block.py
+++ b/tests/test_transformer_block.py
@@ -1,0 +1,30 @@
+import pathlib
+import sys
+import numpy as np
+
+
+def _add_src_to_path() -> None:
+    root = pathlib.Path(__file__).resolve().parents[1]
+    sys.path.append(str(root / "src"))
+    sys.path.append(str(root / "src" / "models"))
+
+
+_add_src_to_path()
+
+from transformer_block import TransformerBlock, TransformerBlockConfig  # noqa: E402
+
+
+def test_transformer_block_numpy() -> None:
+    cfg = TransformerBlockConfig(dim=4, use_complex_attention=False)
+    block = TransformerBlock(cfg)
+    x = np.random.randn(2, 4)
+    out = block(x)
+    assert out.shape == (2, 4)
+
+
+def test_transformer_block_complex_attention() -> None:
+    cfg = TransformerBlockConfig(dim=4, use_complex_attention=True)
+    block = TransformerBlock(cfg)
+    x = np.random.randn(2, 4)
+    out = block(x)
+    assert out.shape == (2, 4)


### PR DESCRIPTION
## Summary
- Reimplement TransformerBlock using pure NumPy, adding manual Linear and attention operations
- Add tests to validate TransformerBlock in both standard and complex attention modes

## Testing
- `python -m py_compile src/models/transformer_block.py tests/test_transformer_block.py`
- `pytest tests/test_transformer_block.py tests/test_complex_attention.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4b53f076c8329ae47ca0ed98ffde8