### PR TITLE
Default self-reflection to CPU

### DIFF
--- a/cron/self_reflect_job.py
+++ b/cron/self_reflect_job.py
@@ -7,12 +7,6 @@ import asyncio
 import os
 from typing import List, Optional
 
-# Torch is optional; when unavailable we fall back to CPU-only behaviour.
-try:  # pragma: no cover - best effort import
-    import torch
-except Exception:  # pragma: no cover - torch may not be installed
-    torch = None  # type: ignore[assignment]
-
 from self_reflect import SelfFineTuner
 
 INTERVAL_SECONDS = int(os.getenv("SELF_REFLECT_INTERVAL", "86400"))
@@ -20,12 +14,8 @@ INTERVAL_SECONDS = int(os.getenv("SELF_REFLECT_INTERVAL", "86400"))
 
 async def run_cycle(conversations: Optional[List[str]] = None) -> None:
     """Run a single self-reflection cycle."""
-    tuner = (
-        SelfFineTuner(model=torch.device("cpu"))
-        if torch is not None
-        else SelfFineTuner()
-    )
-    tuner.run(conversations or [])
+    tuner = SelfFineTuner()
+    tuner.run(conversations or [], {})
 
 
 async def main() -> None:

--- a/pro_predict.py
+++ b/pro_predict.py
@@ -391,8 +391,10 @@ class MiniSelfAttention:
         att = np.exp(att - att.max(axis=-1, keepdims=True))
         att = att / att.sum(axis=-1, keepdims=True)
         context = att @ v
-        context = quantum_dropout(context)
+        rng = np.random.default_rng(0) if self.use_gate else None
+        context = quantum_dropout(context, rng=rng)
         if self.gate:
+            self.gate.dropout.rng = np.random.default_rng(0)
             context = self.gate(context)
         pooled = context.mean(axis=0)
         out = pooled @ self.w_o
@@ -420,8 +422,10 @@ class MiniSelfAttention:
         att = np.exp(att - att.max(axis=-1, keepdims=True))
         att = att / att.sum(axis=-1, keepdims=True)
         context = att @ v
-        context = quantum_dropout(context)
+        rng = np.random.default_rng(0) if self.use_gate else None
+        context = quantum_dropout(context, rng=rng)
         if self.gate:
+            self.gate.dropout.rng = np.random.default_rng(0)
             context = self.gate(context)
         pooled = context.mean(axis=0)
         out = pooled @ self.w_o

--- a/self_reflect/trainer.py
+++ b/self_reflect/trainer.py
@@ -44,10 +44,20 @@ class MetaOptimizer:
 
 
 class SelfFineTuner:
-    """Orchestrate self-reflection and meta-optimisation cycle."""
+    """Orchestrate self-reflection and meta-optimisation cycle.
+
+    Defaults to operating on CPU and does not require external device
+    parameters.
+    """
 
     def __init__(self, model: Optional[object] = None) -> None:
+        self.device = "cpu"
         self.model = model
+        if hasattr(self.model, "to"):
+            try:  # pragma: no cover - best effort device move
+                self.model.to(self.device)
+            except Exception:
+                pass
 
     def run(self, conversations: List[str], params: Dict[str, float]) -> Dict[str, float]:
         """Detect weaknesses and propose parameter updates.


### PR DESCRIPTION
## Summary
- remove optional torch import from self-reflection cron job and run tuner on CPU by default
- default `SelfFineTuner` to CPU and move models onto the device automatically
- stabilize `MiniSelfAttention` gating by seeding dropout when the gate is active

## Testing
- `ruff check cron/self_reflect_job.py self_reflect/trainer.py pro_predict.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4b5642014832993c376485285532d