### PR TITLE
feat: async embedding readiness

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -287,6 +287,7 @@ class ProEngine:
     async def setup(self) -> None:
         pro_predict._GRAPH = {}
         pro_predict._VECTORS = {}
+        pro_memory.COMPRESSION_EVENT = asyncio.Event()
         if os.path.exists(STATE_PATH):
             self.state = pro_tune.load_state(STATE_PATH)
         for key in [


### PR DESCRIPTION
## Summary
- gate prediction updates with an asyncio.Event signaling when embeddings are loaded
- fall back to no-op results while embeddings initialize
- ensure each engine setup uses a fresh compression event

## Testing
- `flake8 pro_predict.py pro_engine.py` *(fails: line too long)*
- `PYTHONPATH=. pytest tests/test_compression_trigger.py::test_compression_runs_after_threshold -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b52f5fb48329926a5048b2c86d59