### PR TITLE
feat: add controllable yields for memory index build

### DIFF
--- a/pro_memory.py
+++ b/pro_memory.py
@@ -73,11 +73,22 @@ def _add_to_index(content: str, embedding: np.ndarray) -> None:
     _STORE.add_utterance("global", "user", content, embedding)
 
 
-async def build_index(batch_size: int = 100) -> None:
-    """Load all stored embeddings into the in-memory index in batches."""
+async def build_index(
+    batch_size: int = 100, yield_every: int | None = None
+) -> None:
+    """Load stored embeddings into the in-memory index in batches.
+
+    Args:
+        batch_size: Number of rows fetched per database query.
+        yield_every: After this many batches, yield control back to the
+            event loop by awaiting ``asyncio.sleep(0)``. If ``None`` or ``0``,
+            no yielding occurs. This allows large indexing jobs to avoid
+            starving the event loop.
+    """
     global _STORE
     offset = 0
     first_batch = True
+    batch_count = 0
     async with get_connection() as conn:
         while True:
             async with conn.execute(
@@ -95,7 +106,9 @@ async def build_index(batch_size: int = 100) -> None:
                 vec = np.frombuffer(blob, dtype=np.float32)
                 _STORE.add_utterance("global", "user", content, vec)
             offset += batch_size
-            await asyncio.sleep(0)
+            batch_count += 1
+            if yield_every and batch_count % yield_every == 0:
+                await asyncio.sleep(0)
     if first_batch:
         _STORE = None
 

--- a/tests/test_build_index_yield.py
+++ b/tests/test_build_index_yield.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import asyncio
+import numpy as np
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pro_memory  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_build_index_yields_control(tmp_path, monkeypatch):
+    db_path = tmp_path / "mem.db"
+    monkeypatch.setattr(pro_memory, "DB_PATH", str(db_path))
+    pro_memory._STORE = None
+    await pro_memory.init_db()
+
+    emb = np.zeros(3, dtype=np.float32)
+    for i in range(5):
+        await pro_memory.persist_embedding(f"msg {i}", emb)
+
+    calls = 0
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay, result=None):
+        nonlocal calls
+        calls += 1
+        return await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    await pro_memory.build_index(batch_size=1, yield_every=2)
+    assert calls == 2
+
+    await pro_memory.close_db()


### PR DESCRIPTION
## Summary
- allow configuring build_index to yield to the event loop every N batches
- remove unconditional sleep for faster index construction
- add regression test to verify periodic yielding

## Testing
- `ruff check pro_memory.py tests/test_build_index_yield.py`
- `pytest tests/test_build_index_yield.py -q`
- `pytest tests/test_memory_vectors.py -q`
- `pytest tests/test_async_round_trip_latency.py -q`
- `pytest tests/test_engine_resilience.py -q` *(fails: ModuleNotFoundError: No module named 'pro_engine')*


------
https://chatgpt.com/codex/tasks/task_e_68b4f2094988832986512a70c4380bda