### PR TITLE
Extend ChatAPI with context retrieval

### DIFF
--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from api.chat import ChatAPI  # noqa: E402
+
+
+def test_process_message_returns_vector_and_context():
+    api = ChatAPI()
+    vec1, ctx1 = api.process_message("dlg", "user", "hello")
+    assert isinstance(vec1, np.ndarray)
+    assert ctx1["dialogue_id"] == "dlg"
+    assert ctx1["speaker"] == "user"
+    assert ctx1["messages"] == ["hello"]
+
+    vec2, ctx2 = api.process_message("dlg", "bot", "hi there")
+    assert ctx2["messages"] == ["hello", "hi there"]
+    assert api.retriever.last_message("dlg", "bot") == "hi there"


### PR DESCRIPTION
## Summary
- extend `ChatAPI.process_message` to return conversation context alongside vectors
- add tests for chat API ensuring history retrieval

## Testing
- `python -m pycodestyle api/chat.py tests/test_api_chat.py`
- `pytest tests/test_api_chat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f3b4e35c8329b5e392ba197b0e3a