### PR TITLE
feat: weighted blend for n-gram and transformer predictions

### DIFF
--- a/tests/test_prediction_blend.py
+++ b/tests/test_prediction_blend.py
@@ -1,0 +1,20 @@
+import pro_predict
+
+
+def test_combination_uses_transformer_when_no_ngram():
+    logits = {"world": 0.9, "hello": 0.1}
+    res = pro_predict.combine_predictions("", logits)
+    assert res[0] == "world"
+    assert len(res) == len(set(res))
+
+
+def test_combination_uses_ngram_when_no_transformer():
+    res = pro_predict.combine_predictions("hello", {})
+    assert res == ["hello"]
+
+
+def test_combination_no_duplicate_words():
+    logits = {"hello": 0.9, "world": 0.1}
+    res = pro_predict.combine_predictions("hello", logits)
+    assert res[0] == "hello"
+    assert len(res) == len(set(res))


### PR DESCRIPTION
## Summary
- add `combine_predictions` to weight n-gram and transformer outputs
- allow `ProEngine` to tune n-gram vs transformer influence via weights
- test that blending falls back to available source and avoids duplicates

## Testing
- `PYTHONPATH=. pytest tests/test_prediction_blend.py`
- `flake8 --select=E9,F63,F7,F82 pro_predict.py pro_engine.py tests/test_prediction_blend.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f60f6a44832980fc6889c440fbab