### PR TITLE
Implement weightless resonant routing and fractal token memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,14 @@ Reflections guide gradual corrections.
 Selects quantum or classical paths from patch features. Decisions refine bandwidth use. This router keeps computations balanced.
 Such design smooths future scaling.
 
+### Weightless Resonant Paths
+
+`router.ResonantRouter` searches for resonant routes without relying on
+learned weights by inspecting Fourier phases of incoming features.  Combined
+with the fractal token embeddings provided by `quantum_memory.QuantumMemory`
+it offers a tiny demonstration of weightless semantics.  Run
+`python scripts/weightless_demo.py` to see both components in action.
+
 ### Peer-to-Peer Resonance
 
 Shares gradient hashes between nodes without central servers. Exchanges apply updates in both directions. These links keep replicas harmonized. This method eases later adjustments.

--- a/quantum_memory.py
+++ b/quantum_memory.py
@@ -13,14 +13,60 @@ import numpy as np
 
 
 class QuantumMemory:
-    """Store complex amplitudes for discrete time steps."""
+    """Store complex amplitudes for discrete time steps.
+
+    Tokens can be provided directly.  They are converted into a fractal
+    representation whose harmonics embody semantic "resonances" at multiple
+    scales.  The encoding is intentionally light-weight – it does not attempt
+    to be linguistically perfect, only to provide a deterministic mapping from
+    a token to a complex vector whose phases repeat self‑similar patterns.
+    """
 
     def __init__(self) -> None:
         self.amplitudes: Dict[int, np.ndarray] = {}
 
-    def store(self, step: int, amps: np.ndarray) -> None:
-        """Store ``amps`` for ``step``."""
+    # ------------------------------------------------------------------
+    # Fractal token encoding
+    def fractal_encode(self, token: str, depth: int = 4) -> np.ndarray:
+        """Return a fractal embedding for ``token``.
 
+        Each level halves the driving frequency which produces a set of
+        harmonics reminiscent of a Mandelbrot zoom.  Summing character codes
+        yields a reproducible seed so the same token always maps to the same
+        spiral of complex amplitudes.
+        """
+
+        seed = sum(ord(c) for c in token)
+        amps = [np.exp(1j * seed / (2 ** i)) for i in range(1, depth + 1)]
+        return np.asarray(amps, dtype=np.complex64)
+
+    def semantic_resonance(self, a: str, b: str) -> float:
+        """Measure resonance between two tokens.
+
+        Cosine similarity in the fractal space acts as a lightweight notion of
+        semantic overlap.
+        """
+
+        va = self.fractal_encode(a)
+        vb = self.fractal_encode(b)
+        denom = np.linalg.norm(va) * np.linalg.norm(vb)
+        if denom == 0:
+            return 0.0
+        return float(np.real(np.vdot(va, vb)) / denom)
+
+    # ------------------------------------------------------------------
+    def store(self, step: int, data: str | np.ndarray) -> None:
+        """Store ``data`` for ``step``.
+
+        ``data`` may be a complex amplitude array or a raw token.  When a
+        token is supplied it is converted to its fractal resonance embedding
+        first.
+        """
+
+        if isinstance(data, np.ndarray):
+            amps = data
+        else:
+            amps = self.fractal_encode(data)
         self.amplitudes[step] = amps
 
     def retrieve(self, step: int) -> np.ndarray | None:

--- a/router/__init__.py
+++ b/router/__init__.py
@@ -1,0 +1,5 @@
+"""Routing strategies used by the engine."""
+
+from .policy import PatchRoutingPolicy, ResonantRouter
+
+__all__ = ["PatchRoutingPolicy", "ResonantRouter"]

--- a/scripts/weightless_demo.py
+++ b/scripts/weightless_demo.py
@@ -1,0 +1,24 @@
+"""Minimal demonstration of weightless resonant routing and fractal memory."""
+
+from quantum_memory import QuantumMemory
+from router import ResonantRouter
+import numpy as np
+
+
+def main() -> None:
+    # Fractal encoding of tokens
+    mem = QuantumMemory()
+    tokens = ["hello", "world"]
+    for i, tok in enumerate(tokens):
+        mem.store(i, tok)
+    print("Fractal amplitudes for 'hello':", mem.retrieve(0))
+
+    # Weightless resonant routing
+    router = ResonantRouter(threshold=0.1)
+    features = np.random.rand(4, 8)
+    mask = router.route(features)
+    print("Resonant routing mask:", mask)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add fractal resonance embeddings for tokens in `QuantumMemory`
- introduce weightless `ResonantRouter` for Fourier-phase path selection
- build responses from semantic diff sequences in `ProEngine`
- document and demo new weightless routing features

## Testing
- `ruff check quantum_memory.py router pro_engine.py scripts/weightless_demo.py`
- `PYTHONPATH=. pytest tests/test_router_policy.py tests/quantum/test_quantum_attention.py`
- `PYTHONPATH=. pytest tests/test_response.py::test_predict_next_word_fallback_to_bigram`


------
https://chatgpt.com/codex/tasks/task_e_68b50a86b5608329be9e7da8dda49bd0