### PR TITLE
Integrate hypergraph memory and context router

### DIFF
--- a/resonance/hypergraph.py
+++ b/resonance/hypergraph.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Set
+
+
+@dataclass
+class Node:
+    """Node in a hypergraph."""
+
+    id: str
+    data: dict | None = None
+
+
+class HyperGraph:
+    """Minimal hypergraph with node and hyperedge management."""
+
+    def __init__(self) -> None:
+        self.nodes: Dict[str, Node] = {}
+        self.edges: List[Set[str]] = []
+        self._order: List[str] = []
+
+    def add_node(
+        self,
+        node_id: str,
+        data: Optional[dict] = None,
+        connect: Optional[Iterable[str]] = None,
+    ) -> None:
+        """Add a node and optional hyperedge connecting ``connect``."""
+
+        self.nodes[node_id] = Node(node_id, data or {})
+        self._order.append(node_id)
+        if connect:
+            edge = set(connect)
+            edge.add(node_id)
+            self.edges.append(edge)
+
+    def get_node(self, node_id: str) -> Node | None:
+        """Return node with ``node_id`` if present."""
+
+        return self.nodes.get(node_id)
+
+    def neighbors(self, node_id: str) -> List[str]:
+        """Return neighboring node ids connected via any hyperedge."""
+
+        result: Set[str] = set()
+        for edge in self.edges:
+            if node_id in edge:
+                result.update(edge)
+        result.discard(node_id)
+        return list(result)
+
+    def trail(self, limit: int) -> List[str]:
+        """Return ``limit`` most recently added node ids."""
+
+        return self._order[-limit:]

--- a/router/__init__.py
+++ b/router/__init__.py
@@ -1,5 +1,6 @@
 """Routing strategies used by the engine."""
 
 from .policy import PatchRoutingPolicy, ResonantRouter
+from .subgraph import select_context_subgraph
 
-__all__ = ["PatchRoutingPolicy", "ResonantRouter"]
+__all__ = ["PatchRoutingPolicy", "ResonantRouter", "select_context_subgraph"]

--- a/router/subgraph.py
+++ b/router/subgraph.py
@@ -1,0 +1,24 @@
+"""Context-based subgraph selection for routing."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from resonance.hypergraph import HyperGraph
+
+
+def select_context_subgraph(
+    graph: HyperGraph, context: Iterable[str]
+) -> HyperGraph:
+    """Return subgraph containing nodes matching ``context`` words."""
+
+    keywords = {w.lower() for w in context}
+    sub = HyperGraph()
+    for node_id, node in graph.nodes.items():
+        content = str(node.data.get("content", "")).lower()
+        if any(k in content for k in keywords):
+            sub.add_node(node_id, node.data)
+            for edge in graph.edges:
+                if node_id in edge:
+                    sub.edges.append(set(edge))
+    return sub

--- a/tests/test_hypergraph_benchmark.py
+++ b/tests/test_hypergraph_benchmark.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import time
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from resonance.hypergraph import HyperGraph
+
+
+def test_hypergraph_load_benchmark():
+    g = HyperGraph()
+    start = time.perf_counter()
+    for i in range(1000):
+        g.add_node(f"n{i}", {"content": str(i)}, connect=[f"n{i-1}"] if i else None)
+    duration = time.perf_counter() - start
+    assert g.get_node("n500") is not None
+    assert duration < 1.0

--- a/tests/test_router_subgraph.py
+++ b/tests/test_router_subgraph.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from resonance.hypergraph import HyperGraph
+from router.subgraph import select_context_subgraph
+
+
+def test_select_context_subgraph():
+    g = HyperGraph()
+    g.add_node("a", {"content": "hello world"})
+    g.add_node("b", {"content": "foo bar"}, connect=["a"])
+    g.add_node("c", {"content": "world peace"}, connect=["b"])
+    sub = select_context_subgraph(g, ["world"])
+    contents = sorted(n.data["content"] for n in sub.nodes.values())
+    assert contents == ["hello world", "world peace"]


### PR DESCRIPTION
## Summary
- add minimal hypergraph implementation for resonance
- switch pro_memory to hypergraph-based history
- introduce context-aware subgraph selection in router
- benchmark hypergraph load and test subgraph routing

## Testing
- `python -m py_compile resonance/hypergraph.py pro_memory.py router/subgraph.py router/__init__.py tests/test_hypergraph_benchmark.py tests/test_router_subgraph.py`
- `pytest tests/test_hypergraph_benchmark.py tests/test_router_subgraph.py -q`
- `pytest tests/test_memory_vectors.py::test_store_and_fetch_similar_embeddings -q`

------
https://chatgpt.com/codex/tasks/task_e_68b50d85cd5c83298c92a49ed4e3bb6f