### PR TITLE
Add 4-bit weight quantization utilities and CPU inference path

### DIFF
--- a/examples/quant4_demo.py
+++ b/examples/quant4_demo.py
@@ -1,0 +1,13 @@
+import numpy as np
+from quantum.quant4 import compress_weights
+from transformers import load_quant4
+
+# Create random weights and compress them
+w = np.random.randn(4, 3).astype(np.float32)
+packed, scale, shape = compress_weights(w)
+np.savez("toy_quant4.npz", packed=packed, scale=scale, shape=shape)
+
+# Load layer and run a forward pass
+layer = load_quant4("toy_quant4.npz")
+x = np.random.randn(2, 4).astype(np.float32)
+print(layer(x))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,4 @@ dependencies = [
 
 [project.optional-dependencies]
 quantum = ["qiskit"]
+quant4 = ["bitarray"]

--- a/quantum/__init__.py
+++ b/quantum/__init__.py
@@ -1,0 +1,3 @@
+from .quant4 import compress_weights, decompress_weights
+
+__all__ = ["compress_weights", "decompress_weights"]

--- a/quantum/quant4.py
+++ b/quantum/quant4.py
@@ -1,0 +1,37 @@
+import numpy as np
+from typing import Tuple
+
+
+def compress_weights(weights: np.ndarray) -> Tuple[np.ndarray, float, Tuple[int, ...]]:
+    """Compress a float32 weight matrix to 4-bit representation.
+
+    Returns
+    -------
+    packed : np.ndarray
+        Array of type ``uint8`` packing two signed 4-bit values per byte.
+    scale : float
+        Scaling factor used during quantisation.
+    shape : tuple[int, ...]
+        Original shape of *weights* for later reconstruction.
+    """
+    if weights.dtype != np.float32:
+        weights = weights.astype(np.float32)
+    max_abs = float(np.max(np.abs(weights)))
+    if max_abs == 0.0:
+        max_abs = 1.0
+    scale = max_abs / 7.0
+    q = np.clip(np.round(weights / scale), -8, 7).astype(np.int8).ravel()
+    if q.size % 2:
+        q = np.pad(q, (0, 1), mode="constant")
+    packed = ((q[0::2] & 0xF) << 4) | (q[1::2] & 0xF)
+    return packed.astype(np.uint8), scale, weights.shape
+
+
+def decompress_weights(packed: np.ndarray, scale: float, shape: Tuple[int, ...]) -> np.ndarray:
+    """Restore 4-bit packed weights back to float32 array."""
+    q = np.empty(packed.size * 2, dtype=np.int8)
+    q[0::2] = (packed >> 4) & 0xF
+    q[1::2] = packed & 0xF
+    q = ((q + 8) % 16) - 8
+    q = q[: np.prod(shape)]
+    return (q.astype(np.float32) * scale).reshape(shape)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ aiohttp
 
 # Optional quantum dependencies
 # qiskit (install with `pip install .[quantum]`)
+
+# Optional quantisation dependencies
+# bitarray (install with `pip install bitarray`)

--- a/tests/test_quant4.py
+++ b/tests/test_quant4.py
@@ -1,0 +1,10 @@
+import numpy as np
+from quantum.quant4 import compress_weights, decompress_weights
+
+
+def test_quant4_roundtrip():
+    w = np.random.randn(7, 5).astype(np.float32)
+    packed, scale, shape = compress_weights(w)
+    restored = decompress_weights(packed, scale, shape)
+    assert restored.shape == w.shape
+    assert np.allclose(restored, w, atol=scale)

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -2,6 +2,7 @@ from .blocks import DynamicContextGate, ResonantDropout
 from .modeling_transformer import MemoryAttention, register_kernel
 from .quantum_attention import QuantumAttention
 from .time_fold import TimeFoldTransformer
+from .quant4_infer import Quant4Linear, load_quant4
 
 __all__ = [
     "DynamicContextGate",
@@ -10,6 +11,8 @@ __all__ = [
     "register_kernel",
     "QuantumAttention",
     "TimeFoldTransformer",
+    "Quant4Linear",
+    "load_quant4",
     "get_attention",
 ]
 

--- a/transformers/quant4_infer.py
+++ b/transformers/quant4_infer.py
@@ -1,0 +1,33 @@
+"""Utilities for running 4-bit quantised weights on CPU."""
+
+from __future__ import annotations
+
+import numpy as np
+from quantum.quant4 import decompress_weights
+
+
+class Quant4Linear:
+    """Minimal linear layer using 4-bit packed weights."""
+
+    def __init__(self, packed: np.ndarray, scale: float, shape: tuple[int, int], bias: np.ndarray | None = None) -> None:
+        self.packed = packed
+        self.scale = scale
+        self.shape = shape
+        self.bias = bias
+
+    def __call__(self, x: np.ndarray) -> np.ndarray:
+        weight = decompress_weights(self.packed, self.scale, self.shape)
+        out = x @ weight
+        if self.bias is not None:
+            out = out + self.bias
+        return out
+
+
+def load_quant4(path: str) -> Quant4Linear:
+    """Load ``Quant4Linear`` weights from an ``npz`` file."""
+    data = np.load(path)
+    packed = data["packed"]
+    scale = float(data["scale"])
+    shape = tuple(data["shape"])
+    bias = data.get("bias")
+    return Quant4Linear(packed, scale, shape, bias)


### PR DESCRIPTION
## Summary
- implement 4-bit weight compression and restoration utilities
- add CPU inference helper that loads 4-bit weights
- document usage via example script and optional requirements

## Testing
- `PYTHONPATH=. pytest tests/test_quant4.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b50b0485148329a80072a9b2cb3a8b