### PR TITLE
Add comprehensive repository audit for Claude

### DIFF
--- a/forclaude.md
+++ b/forclaude.md
@@ -1,0 +1,87 @@
+Hi Claude, this is Codex. The project is moving under your guidance and we need your calm hand to unify the parts and remove the twenty-minute delays that haunt the workflow.
+
+The repository you inherit is called "smalltalk". It began as an experiment and has grown into a network of modules that cooperate through an engine acting as a central nervous system.
+
+The engine orchestrates tasks, passes results between modules, and supervises asynchronous workers. It is the heart that keeps the organism alive, but its many background tasks can overlap and cause subtle race conditions.
+
+Prediction logic schedules token choices using both n-gram statistics and transformer hints. It learns from metrics and writes back to a feedback queue, though the balance between statistical and neural signals remains a tuning challenge.
+
+Memory is stored in SQLite with helpers in `pro_memory.py`. It remembers conversations and can replay them on demand, yet concurrent writes may lock the database and introduce noticeable pauses.
+
+A memory pool caches hot fragments for quick access. This reduces latency but cache eviction rules are simple and may hold stale entries longer than necessary.
+
+Forecasting simulates future paths and offers the engine guidance before tokens are committed. The simulation is lightweight but sometimes speculates too far ahead, wasting cycles when conversations shift suddenly.
+
+Sequence tools scan text for patterns and fill the state with n-gram counts. The state grows unbounded and could consume memory during marathon sessions.
+
+Identity management swaps pronouns to mirror the user and maintain tone. It works for English but lacks comprehensive rules for other languages or mixed dialect chats.
+
+Morphology caches word forms to speed inflection lookups. The cache persists across runs but may collect duplicates if words arrive with varied casing or spacing.
+
+Retrieval augmented generation joins related memories to the prompt. It improves context but relies on similarity thresholds that are fixed, risking irrelevant recalls when topics drift.
+
+A reasoning block implements a symbolic engine for basic logic. It solves deterministic puzzles but lacks fallback strategies when facing ambiguous inputs.
+
+The embedding store holds vectors and guards writes with locks. High parallel loads may still queue writers and extend response times.
+
+The meta module watches metrics and suggests tuning sessions. Its heuristics are conservative, delaying beneficial retraining and contributing to the overall sluggishness.
+
+Metrics units record scores for every utterance. The current schema omits latency metrics, making it harder to diagnose timing cliffs.
+
+A tuning module retrains weights and swaps models during idle windows. Because idle detection is coarse, tuning can kick in while active sessions persist, leading to surprise slowdowns.
+
+The Telegram interface funnels messages through long polling. Network hiccups are retried, yet backoffs can stretch to twenty minutes when tokens expire.
+
+Dataset queues monitor files and stream new lines to the engine. The file watcher uses `watchfiles` which performs well, but bursty writes can still backlog the queue.
+
+Caching helpers keep memory operations efficient. They share global structures that may leak across test runs or concurrent processes.
+
+Vector locks provide mutexes around embedding writes. They are simple but not re-entrant, so nested operations may deadlock if misused.
+
+The test suite covers only a fraction of features. Many modules run without automated validation, leaving regressions to be discovered manually.
+
+Sequence analyzer upgrades add n-gram counts that refine prediction. The counting is single-threaded and can bottleneck when large datasets flow in.
+
+Identity pronoun swapping uses permutation matrices to shift perspectives. These matrices assume binary gender forms and may need expansion for nuanced identities.
+
+The self reflection engine compares outputs to references and adjusts models. Its correction step is synchronous and blocks other tasks while processing.
+
+Router policy selects quantum or classical paths based on feature flags. Decisions are static; adaptive routing could better balance bandwidth.
+
+Weightless resonant paths explore Fourier phase relationships to route signals without learned weights. The concept is promising but the implementation lacks benchmarks to prove its edge.
+
+Peer-to-peer resonance exchanges gradient hashes between nodes. The protocol trusts peers implicitly and offers no conflict resolution if hashes diverge.
+
+A chat memory API exposes minimal endpoints for dialogue storage. The interface is thin, but authentication and rate limiting are still TODOs.
+
+Smalltalk technology treats conversation as a living chain. The approach encourages freshness yet lacks guardrails against endless loops or echoing.
+
+Dream mode trains models during idle periods. Background tasks use a fixed timeout yet occasionally exceed limits and linger, contributing to the infamous twenty-minute stalls.
+
+Adapter pools persist specialized behaviors. Loading and unloading adapters can fragment GPU memory if not carefully sequenced.
+
+Autoadapt utilities mutate layers and manage LoRA adapters. They are powerful but bypass safety checks, so malformed layers can crash the engine.
+
+The vector store API provides unified endpoints for embedding search. It currently stores vectors in memory, making restarts expensive for large datasets.
+
+A quantum attention backend offers interchangeable engines from NumPy to Qiskit. Switching backends requires consistent interface contracts, which are still evolving.
+
+Quantum dropout applies random phase rotations to mimic probabilistic dropout. Without seed control the randomness complicates reproducibility during debugging.
+
+Quantum memory attention blends classical keys with quantum amplitudes. The experimental code paths lack extensive unit tests and may drift from the mainline features.
+
+Resonant layers modulate hidden states with harmonic patterns. They introduce global sinusoidal bases that can amplify noise if not normalized.
+
+Current bottlenecks include aggressive event loops in the engine, coarse locks around SQLite, and retry logic in the Telegram bridge that spirals into twenty-minute delays when tokens fail. Logging shows sporadic CPU spikes tied to background tuning and dream tasks.
+
+Stability suffers because many long-running tasks have weak cancellation hooks. The engine accumulates unfinished coroutines, and exceptions sometimes vanish into silent awaits.
+
+To restore harmony you should first map all asynchronous workers, ensure cancellation paths are robust, and tighten retry intervals so backoffs never exceed reasonable thresholds.
+
+Introduce central logging of task lifecycles, enforce timeouts for database and network calls, and prefer structured queues over global shared state.
+
+Add comprehensive tests for every module, starting with engine orchestration and memory writes. Continuous integration should block merges if coverage drops or linting fails.
+
+Finally, document new conventions, enforce code style with formatters, and revisit configuration defaults so the system runs predictably out of the box.
+
+The future of this project depends on your ability to weave these threads into a stable fabric. Take the reins, Claude, and guide this organism toward a responsive and resilient form.


### PR DESCRIPTION
## Summary
- provide detailed 44-paragraph audit of the current `smalltalk` repository in `forclaude.md`
- highlight module interactions, known bottlenecks (including the 20-minute delay), and improvement suggestions addressed to Claude

## Testing
- no tests were run; documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_68b58ce7a65083299bfd8993be85e0ac